### PR TITLE
Feature/add models

### DIFF
--- a/todo_mini/lib/data/models/app_user.dart
+++ b/todo_mini/lib/data/models/app_user.dart
@@ -1,0 +1,63 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// 유저 역할
+/// - user: 일반 사용자(공지 읽기, 내 todo 읽기/상태 변경)
+/// - admin: 관리자(todo/notice CRUD)
+enum UserRole { user, admin }
+
+/// Firestore 컬렉션: users
+/// 문서 ID: uid
+///
+/// 필드(스펙):
+/// - name: string (필수)
+/// - role: "admin" | "user" (필수)
+/// - createdAt: timestamp (필수; serverTimestamp 권장)
+class AppUser {
+  final String id; // Firestore 문서 ID = Firebase Auth uid
+  final String name;
+  final UserRole role;
+  final DateTime createdAt;
+
+  AppUser({
+    required this.id,
+    required this.name,
+    required this.role,
+    required this.createdAt,
+  });
+
+  /// Firestore DocumentSnapshot -> AppUser 변환
+  /// - createdAt이 없거나 잘못된 경우 대비: DateTime.now() fallback
+  factory AppUser.fromDoc(DocumentSnapshot<Map<String, dynamic>> doc) {
+    final data = doc.data();
+    if (data == null) {
+      throw StateError('AppUser.fromDoc: document data is null (${doc.id})');
+    }
+
+    final roleStr = (data['role'] ?? 'user') as String;
+
+    return AppUser(
+      id: doc.id,
+      name: (data['name'] ?? '') as String,
+      role: roleStr == 'admin' ? UserRole.admin : UserRole.user,
+      createdAt: (data['createdAt'] as Timestamp?)?.toDate() ?? DateTime.now(),
+    );
+  }
+
+  /// 저장/업데이트에 쓰는 JSON.
+  /// createdAt/updatedAt 같은 서버 타임스탬프는 Repository에서 serverTimestamp로 넣는 것을 권장.
+  Map<String, dynamic> toJson() => {
+    'name': name,
+    'role': role == UserRole.admin ? 'admin' : 'user',
+  };
+
+  /// 테스트/디버깅에 유용한 생성자(선택)
+  factory AppUser.fromJson(String id, Map<String, dynamic> json) {
+    final roleStr = (json['role'] ?? 'user') as String;
+    return AppUser(
+      id: id,
+      name: (json['name'] ?? '') as String,
+      role: roleStr == 'admin' ? UserRole.admin : UserRole.user,
+      createdAt: (json['createdAt'] as Timestamp?)?.toDate() ?? DateTime.now(),
+    );
+  }
+}

--- a/todo_mini/lib/data/models/notice.dart
+++ b/todo_mini/lib/data/models/notice.dart
@@ -1,0 +1,44 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// Firestore 컬렉션: notices
+///
+/// 필드(스펙):
+/// - title: string (필수, 1~80)
+/// - content: string (필수, 1~2000)
+/// - createdAt: timestamp (필수)
+/// - updatedAt: timestamp (필수)
+class Notice {
+  final String id;
+  final String title;
+  final String content;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  Notice({
+    required this.id,
+    required this.title,
+    required this.content,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  factory Notice.fromDoc(DocumentSnapshot<Map<String, dynamic>> doc) {
+    final data = doc.data();
+    if (data == null) {
+      throw StateError('Notice.fromDoc: document data is null (${doc.id})');
+    }
+
+    return Notice(
+      id: doc.id,
+      title: (data['title'] ?? '') as String,
+      content: (data['content'] ?? '') as String,
+      createdAt: (data['createdAt'] as Timestamp?)?.toDate() ?? DateTime.now(),
+      updatedAt: (data['updatedAt'] as Timestamp?)?.toDate() ?? DateTime.now(),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'title': title,
+    'content': content,
+  };
+}

--- a/todo_mini/lib/data/models/todo.dart
+++ b/todo_mini/lib/data/models/todo.dart
@@ -1,0 +1,69 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// Todo 상태
+enum TodoStatus { open, done }
+
+/// Firestore 컬렉션: todos
+///
+/// 필드(스펙):
+/// - title: string (필수, 1~50)
+/// - description: string? (선택)
+/// - dueDate: timestamp? (선택)
+/// - status: "open" | "done" (필수)
+/// - assigneeId: string (필수: users.uid)
+/// - createdAt: timestamp (필수)
+/// - updatedAt: timestamp (필수)
+class Todo {
+  final String id;
+  final String title;
+  final String? description;
+  final DateTime? dueDate;
+  final TodoStatus status;
+  final String assigneeId;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  Todo({
+    required this.id,
+    required this.title,
+    required this.description,
+    required this.dueDate,
+    required this.status,
+    required this.assigneeId,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  factory Todo.fromDoc(DocumentSnapshot<Map<String, dynamic>> doc) {
+    final data = doc.data();
+    if (data == null) {
+      throw StateError('Todo.fromDoc: document data is null (${doc.id})');
+    }
+
+    final statusStr = (data['status'] ?? 'open') as String;
+
+    return Todo(
+      id: doc.id,
+      title: (data['title'] ?? '') as String,
+      description: data['description'] as String?,
+      dueDate: (data['dueDate'] as Timestamp?)?.toDate(),
+      status: statusStr == 'done' ? TodoStatus.done : TodoStatus.open,
+      assigneeId: (data['assigneeId'] ?? '') as String,
+      createdAt: (data['createdAt'] as Timestamp?)?.toDate() ?? DateTime.now(),
+      updatedAt: (data['updatedAt'] as Timestamp?)?.toDate() ?? DateTime.now(),
+    );
+  }
+
+  /// Firestore write 용 JSON(필요한 필드만)
+  /// - createdAt/updatedAt은 Repository에서 serverTimestamp 권장
+  Map<String, dynamic> toJson() => {
+    'title': title,
+    'description': description,
+    'dueDate': dueDate == null ? null : Timestamp.fromDate(dueDate!),
+    'status': status == TodoStatus.done ? 'done' : 'open',
+    'assigneeId': assigneeId,
+  };
+
+  /// UI에서 토글 처리를 쉽게 하기 위한 헬퍼
+  TodoStatus get toggledStatus => status == TodoStatus.done ? TodoStatus.open : TodoStatus.done;
+}

--- a/todo_mini/test/data/models/app_user_test.dart
+++ b/todo_mini/test/data/models/app_user_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:todo_mini/data/models/app_user.dart';
+
+void main() {
+  test('AppUser toJson should map role correctly', () {
+    final u1 = AppUser(
+      id: 'uid',
+      name: 'Kim',
+      role: UserRole.user,
+      createdAt: DateTime(2026, 1, 1),
+    );
+    expect(u1.toJson()['role'], 'user');
+
+    final u2 = AppUser(
+      id: 'uid',
+      name: 'Admin',
+      role: UserRole.admin,
+      createdAt: DateTime(2026, 1, 1),
+    );
+    expect(u2.toJson()['role'], 'admin');
+  });
+
+  test('AppUser fromJson should parse timestamp and role', () {
+    final json = {
+      'name': 'Lee',
+      'role': 'admin',
+      'createdAt': Timestamp.fromDate(DateTime(2026, 2, 1)),
+    };
+
+    final user = AppUser.fromJson('uid_1', json);
+    expect(user.id, 'uid_1');
+    expect(user.name, 'Lee');
+    expect(user.role, UserRole.admin);
+    expect(user.createdAt, DateTime(2026, 2, 1));
+  });
+}

--- a/todo_mini/test/data/models/notice_test.dart
+++ b/todo_mini/test/data/models/notice_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:todo_mini/data/models/notice.dart';
+
+void main() {
+  test('Notice toJson should include title/content only', () {
+    final notice = Notice(
+      id: 'n1',
+      title: 'Hello',
+      content: 'World',
+      createdAt: DateTime(2026, 2, 1),
+      updatedAt: DateTime(2026, 2, 1),
+    );
+
+    final json = notice.toJson();
+    expect(json.keys, containsAll(['title', 'content']));
+    expect(json.keys, isNot(contains('createdAt')));
+    expect(json.keys, isNot(contains('updatedAt')));
+  });
+}

--- a/todo_mini/test/data/models/todo_test.dart
+++ b/todo_mini/test/data/models/todo_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:todo_mini/data/models/todo.dart';
+
+void main() {
+  test('Todo toJson should serialize dueDate/status', () {
+    final todo = Todo(
+      id: 't1',
+      title: 'Read docs',
+      description: 'project onboarding',
+      dueDate: DateTime(2026, 2, 10),
+      status: TodoStatus.open,
+      assigneeId: 'uid_1',
+      createdAt: DateTime(2026, 2, 1),
+      updatedAt: DateTime(2026, 2, 1),
+    );
+
+    final json = todo.toJson();
+    expect(json['title'], 'Read docs');
+    expect(json['status'], 'open');
+    expect(json['assigneeId'], 'uid_1');
+    expect(json['dueDate'], isA<Timestamp>());
+  });
+
+  test('Todo toggledStatus should switch between open/done', () {
+    final openTodo = Todo(
+      id: 't',
+      title: 't',
+      description: null,
+      dueDate: null,
+      status: TodoStatus.open,
+      assigneeId: 'u',
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+    );
+    expect(openTodo.toggledStatus, TodoStatus.done);
+
+    final doneTodo = Todo(
+      id: 't',
+      title: 't',
+      description: null,
+      dueDate: null,
+      status: TodoStatus.done,
+      assigneeId: 'u',
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+    );
+    expect(doneTodo.toggledStatus, TodoStatus.open);
+  });
+}


### PR DESCRIPTION
## What
- AppUser/Todo/Notice 모델 추가
- enum(UserRole, TodoStatus) 정의
- Firestore 변환(fromDoc) 및 write(toJson) 지원
- 모델 단위 테스트 추가

## Why
- Firestore 데이터 구조를 코드로 명확히 고정하고,
  Repository/ViewModel에서 타입 안정적으로 사용하기 위함

## How
- createdAt/updatedAt은 Repository에서 serverTimestamp로 관리하도록 toJson에서 제외
- Timestamp 변환 및 null fallback 처리

## Checklist
- [v] flutter test 통과
- [v] 모델 스키마가 과제 스펙과 일치
- [v] toJson이 write 최소 필드만 포함하는지 확인
