### PR TITLE
Feature/add data sources

### DIFF
--- a/todo_mini/devtools_options.yaml
+++ b/todo_mini/devtools_options.yaml
@@ -1,0 +1,3 @@
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:

--- a/todo_mini/lib/data/datasources/firebase_auth_ds.dart
+++ b/todo_mini/lib/data/datasources/firebase_auth_ds.dart
@@ -1,0 +1,75 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+
+class FirebaseAuthDataSource {
+  final FirebaseAuth _auth;
+
+  // v7+ : 생성자 대신 싱글톤 instance 사용
+  final GoogleSignIn _googleSignIn;
+
+  // v7+ : initialize가 비동기라, 1회만 보장하기 위해 플래그 둠
+  bool _googleInitialized = false;
+
+  // 필요하면 clientId/serverClientId를 외부에서 주입 가능 (웹/서버 연동 시)
+  final String? _clientId;
+  final String? _serverClientId;
+
+  FirebaseAuthDataSource(
+      this._auth, {
+        GoogleSignIn? googleSignIn,
+        String? clientId,
+        String? serverClientId,
+      })  : _googleSignIn = googleSignIn ?? GoogleSignIn.instance,
+        _clientId = clientId,
+        _serverClientId = serverClientId;
+
+  Stream<User?> authStateChanges() => _auth.authStateChanges();
+  User? get currentUser => _auth.currentUser;
+
+  Future<UserCredential> signIn(String email, String password) {
+    return _auth.signInWithEmailAndPassword(email: email, password: password);
+  }
+
+  Future<UserCredential> signUp(String email, String password) {
+    return _auth.createUserWithEmailAndPassword(email: email, password: password);
+  }
+
+  Future<void> _ensureGoogleInitialized() async {
+    if (_googleInitialized) return;
+    await _googleSignIn.initialize(
+      clientId: _clientId,
+      serverClientId: _serverClientId,
+    );
+    _googleInitialized = true;
+  }
+
+  /// ✅ Google 로그인 (google_sign_in v7+)
+  /// - 로그인(인증): authenticate()
+  /// - Firebase Auth에는 idToken만 있어도 credential 생성 가능 (accessToken은 선택)
+  ///   google_sign_in v7에서 auth 토큰은 idToken만 제공됩니다. :contentReference[oaicite:1]{index=1}
+  Future<UserCredential> signInWithGoogle({
+    List<String> scopeHint = const <String>[],
+  }) async {
+    await _ensureGoogleInitialized();
+
+    // v7: signIn() 없음 -> authenticate()
+    final account = await _googleSignIn.authenticate(scopeHint: scopeHint);
+
+    final idToken = account.authentication.idToken;
+    if (idToken == null) {
+      throw StateError('Google idToken is null');
+    }
+
+    // Firebase 문서에서도 Google sign-in → credential → signInWithCredential 흐름 :contentReference[oaicite:2]{index=2}
+    final credential = GoogleAuthProvider.credential(idToken: idToken);
+    return _auth.signInWithCredential(credential);
+  }
+
+  Future<void> signOut() async {
+    await _auth.signOut();
+    // google_sign_in v7: signOut 메서드 존재 :contentReference[oaicite:3]{index=3}
+    try {
+      await _googleSignIn.signOut();
+    } catch (_) {}
+  }
+}

--- a/todo_mini/lib/data/datasources/firestore_ds.dart
+++ b/todo_mini/lib/data/datasources/firestore_ds.dart
@@ -1,0 +1,23 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// Firestore SDK 접근을 캡슐화하는 DataSource입니다.
+/// - 컬렉션 경로를 한 군데로 모아서 오타/중복을 줄입니다.
+/// - Repository에서만 사용하도록 설계합니다.
+class FirestoreDataSource {
+  final FirebaseFirestore _db;
+
+  FirestoreDataSource(this._db);
+
+  /// users 컬렉션
+  CollectionReference<Map<String, dynamic>> users() => _db.collection('users');
+
+  /// todos 컬렉션
+  CollectionReference<Map<String, dynamic>> todos() => _db.collection('todos');
+
+  /// notices 컬렉션
+  CollectionReference<Map<String, dynamic>> notices() => _db.collection('notices');
+
+  /// 서버 시간 타임스탬프(권장)
+  /// - createdAt/updatedAt에 사용
+  FieldValue serverTimestamp() => FieldValue.serverTimestamp();
+}

--- a/todo_mini/pubspec.lock
+++ b/todo_mini/pubspec.lock
@@ -9,6 +9,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.66"
+  adaptive_number:
+    dependency: transitive
+    description:
+      name: adaptive_number
+      sha256: "3a567544e9b5c9c803006f51140ad544aedc79604fd4f3f2c1380003f97c1d77"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  antlr4:
+    dependency: transitive
+    description:
+      name: antlr4
+      sha256: "752b4a6e4ad97953652a2b2bbf5377f46c94b579d3372b50080c7e5858234a05"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.13.2"
   async:
     dependency: transitive
     description:
@@ -25,6 +41,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  cel:
+    dependency: transitive
+    description:
+      name: cel
+      sha256: "51d77e16424d41b5fdb0a239be4c8a0550d4dd3f952801d35375ddd90cfb49da"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.4+1"
   characters:
     dependency: transitive
     description:
@@ -73,6 +97,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  convert:
+    dependency: transitive
+    description:
+      name: convert
+      sha256: b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.2"
+  crypto:
+    dependency: transitive
+    description:
+      name: crypto
+      sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.7"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -81,6 +121,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
+  dart_jsonwebtoken:
+    dependency: transitive
+    description:
+      name: dart_jsonwebtoken
+      sha256: "0de65691c1d736e9459f22f654ddd6fd8368a271d4e41aa07e53e6301eff5075"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.3.1"
+  ed25519_edwards:
+    dependency: transitive
+    description:
+      name: ed25519_edwards
+      sha256: "6ce0112d131327ec6d42beede1e5dfd526069b18ad45dcf654f15074ad9276cd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: "3e0141505477fd8ad55d6eb4e7776d3fe8430be8e497ccb1521370c3f21a3e2b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.8"
   fake_async:
     dependency: transitive
     description:
@@ -89,6 +153,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
+  fake_cloud_firestore:
+    dependency: "direct dev"
+    description:
+      name: fake_cloud_firestore
+      sha256: "1e1f1d79139277069577cc80bec2930ee4d3fcc0f4a8936549160d41c3858ec0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.1"
+  fake_firebase_security_rules:
+    dependency: transitive
+    description:
+      name: fake_firebase_security_rules
+      sha256: "7a9011d42d99848ece92784fed5a20167ad76da66de2c1102a2bc053e66b0305"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.3"
   firebase_auth:
     dependency: "direct main"
     description:
@@ -97,6 +177,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.4"
+  firebase_auth_mocks:
+    dependency: "direct dev"
+    description:
+      name: firebase_auth_mocks
+      sha256: ee1076150ea51d181ae24d5f8e2686a1926b7cc54e25c0deaa8ac58705025551
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.15.1"
   firebase_auth_platform_interface:
     dependency: transitive
     description:
@@ -137,6 +225,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.4.0"
+  fixnum:
+    dependency: transitive
+    description:
+      name: fixnum
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -256,6 +352,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
+  logger:
+    dependency: transitive
+    description:
+      name: logger
+      sha256: a7967e31b703831a893bbc3c3dd11db08126fe5f369b5c648a36f821979f5be3
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.2"
+  logging:
+    dependency: transitive
+    description:
+      name: logging
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   matcher:
     dependency: transitive
     description:
@@ -280,6 +392,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.16.0"
+  mock_exceptions:
+    dependency: transitive
+    description:
+      name: mock_exceptions
+      sha256: "6e3e623712d2c6106ffe9e14732912522b565ddaa82a8dcee6cd4441b5984056"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.2"
+  more:
+    dependency: transitive
+    description:
+      name: more
+      sha256: d3908d710f78ee5470d2ae9d7599a11aeb00a17909cc36cbd0f23a0b659ca375
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.0"
   nested:
     dependency: transitive
     description:
@@ -304,6 +432,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  pointycastle:
+    dependency: transitive
+    description:
+      name: pointycastle
+      sha256: "92aa3841d083cc4b0f4709b5c74fd6409a3e6ba833ffc7dc6a8fee096366acf5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.0"
   provider:
     dependency: "direct main"
     description:
@@ -312,6 +448,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.5+1"
+  quiver:
+    dependency: transitive
+    description:
+      name: quiver
+      sha256: ea0b925899e64ecdfbf9c7becb60d5b50e706ade44a85b2363be2a22d88117d2
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  rx:
+    dependency: transitive
+    description:
+      name: rx
+      sha256: "7f54bd39cc63a01c770c1de4b6ce8e135eb13119614cba2216bd9a93ccd29e56"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.0"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.28.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -365,6 +525,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.4"
+  tuple:
+    dependency: transitive
+    description:
+      name: tuple
+      sha256: a97ce2013f240b2f3807bcbaf218765b6f301c3eff91092bcfa23a039e7dd151
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   typed_data:
     dependency: transitive
     description:
@@ -373,6 +541,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      sha256: a11b666489b1954e01d992f3d601b1804a33937b5a8fe677bd26b8a9f96f96e8
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.2"
   vector_math:
     dependency: transitive
     description:

--- a/todo_mini/pubspec.yaml
+++ b/todo_mini/pubspec.yaml
@@ -19,11 +19,14 @@ dependencies:
   cloud_firestore: ^6.1.2
   google_sign_in: ^7.2.0
 
+
 dev_dependencies:
   flutter_test:
     sdk: flutter
 
   flutter_lints: ^5.0.0
+  fake_cloud_firestore: ^4.0.1
+  firebase_auth_mocks: ^0.15.1
 
 flutter:
 

--- a/todo_mini/test/data/datasources/firebase_auth_ds_test.dart
+++ b/todo_mini/test/data/datasources/firebase_auth_ds_test.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
+import 'package:todo_mini/data/datasources/firebase_auth_ds.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('FirebaseAuthDataSource should be creatable (no firebase init needed)', () {
+    final mockAuth = MockFirebaseAuth();
+    final ds = FirebaseAuthDataSource(mockAuth);
+
+    expect(() => ds.currentUser, returnsNormally);
+    expect(ds.authStateChanges(), isA<Stream>());
+  });
+}

--- a/todo_mini/test/data/datasources/firestore_ds_test.dart
+++ b/todo_mini/test/data/datasources/firestore_ds_test.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:todo_mini/data/datasources/firestore_ds.dart';
+
+void main() {
+  test('FirestoreDataSource should provide collection references', () {
+    final fakeDb = FakeFirebaseFirestore();
+    final ds = FirestoreDataSource(fakeDb);
+
+    expect(ds.users().path, 'users');
+    expect(ds.todos().path, 'todos');
+    expect(ds.notices().path, 'notices');
+  });
+}


### PR DESCRIPTION
# PR: feature/addDataSources

## What
- Firebase SDK 접근을 캡슐화하기 위한 **DataSource 레이어**를 추가했습니다.
  - `FirebaseAuthDataSource`
    - `authStateChanges()`, `signIn()`, `signUp()`, `signOut()`
    - **Google 로그인** `signInWithGoogle()` 추가
  - `FirestoreDataSource`
    - `users() / todos() / notices()` 컬렉션 레퍼런스 제공
    - `serverTimestamp()` 헬퍼 제공
- Unit test 환경에서 Firebase 초기화/플러그인 채널 의존을 피하도록 **테스트 안정화**를 적용했습니다.
  - Firestore: `FakeFirebaseFirestore` 기반 테스트
  - Auth: mock 기반 테스트(또는 GoogleSignIn 접근을 lazy 처리)

---

## Why
- MVVM 구조에서 **ViewModel이 Firebase SDK에 직접 의존하지 않도록** 하기 위함입니다.
- Data 접근을 DataSource/Repository로 분리하여 다음을 확보합니다.
  - 관심사 분리(비즈니스 로직 ↔ 데이터 접근)
  - 테스트 용이성(플러그인/네트워크 의존 제거)
  - 추후 구현 교체 가능성(예: API 서버/로컬 DB)

---

## How
- DataSource는 **SDK 호출 위임만 담당**하도록 얇게 유지했습니다.  
  (비즈니스 규칙/권한 판단/데이터 가공은 Repository에서 처리)
- Google 로그인 플로우:
  1. `GoogleSignIn.authenticate()`로 계정 인증
  2. `idToken` 획득
  3. `GoogleAuthProvider.credential(idToken: ...)` 생성
  4. `FirebaseAuth.signInWithCredential()` 호출
- signOut 시:
  - Firebase 로그아웃 후, Google 세션도 함께 정리(실패해도 앱 동작에는 영향 없도록 try/catch)

---

## Files
- `lib/data/datasources/firebase_auth_ds.dart`
- `lib/data/datasources/firestore_ds.dart`
- `test/data/datasources/firebase_auth_ds_test.dart`
- `test/data/datasources/firestore_ds_test.dart`

---

## Test
```bash
flutter test

--

 [v]flutter test 통과

 [v]Firebase SDK 호출이 UI/VM에 노출되지 않음(DataSource로 캡슐화)

 [v]Firestore 컬렉션 path 고정(users/todos/notices)

 [v]Google 로그인 추가 및 로그아웃 시 세션 정리 포함
