### PR TITLE
Feature/add repositories

### DIFF
--- a/todo_mini/lib/data/datasources/firebase_auth_ds.dart
+++ b/todo_mini/lib/data/datasources/firebase_auth_ds.dart
@@ -5,7 +5,7 @@ class FirebaseAuthDataSource {
   final FirebaseAuth _auth;
 
   // v7+ : 생성자 대신 싱글톤 instance 사용
-  final GoogleSignIn _googleSignIn;
+ GoogleSignIn? _googleSignIn;
 
   // v7+ : initialize가 비동기라, 1회만 보장하기 위해 플래그 둠
   bool _googleInitialized = false;
@@ -23,6 +23,9 @@ class FirebaseAuthDataSource {
         _clientId = clientId,
         _serverClientId = serverClientId;
 
+  GoogleSignIn get _gs => _googleSignIn ??= GoogleSignIn.instance; // ✅ 필요할 때만
+
+
   Stream<User?> authStateChanges() => _auth.authStateChanges();
   User? get currentUser => _auth.currentUser;
 
@@ -36,7 +39,7 @@ class FirebaseAuthDataSource {
 
   Future<void> _ensureGoogleInitialized() async {
     if (_googleInitialized) return;
-    await _googleSignIn.initialize(
+    await _gs.initialize(
       clientId: _clientId,
       serverClientId: _serverClientId,
     );
@@ -53,7 +56,7 @@ class FirebaseAuthDataSource {
     await _ensureGoogleInitialized();
 
     // v7: signIn() 없음 -> authenticate()
-    final account = await _googleSignIn.authenticate(scopeHint: scopeHint);
+    final account = await _gs.authenticate(scopeHint: scopeHint);
 
     final idToken = account.authentication.idToken;
     if (idToken == null) {
@@ -69,7 +72,7 @@ class FirebaseAuthDataSource {
     await _auth.signOut();
     // google_sign_in v7: signOut 메서드 존재 :contentReference[oaicite:3]{index=3}
     try {
-      await _googleSignIn.signOut();
+      await _gs.signOut();
     } catch (_) {}
   }
 }

--- a/todo_mini/lib/data/repositories/auth_repository.dart
+++ b/todo_mini/lib/data/repositories/auth_repository.dart
@@ -1,0 +1,14 @@
+/// 상위 레이어(ViewModel)는 FirebaseAuth를 직접 몰라도 되도록
+/// "AuthRepository" 인터페이스로 추상화합니다.
+abstract class AuthRepository {
+  /// uid 스트림 (로그인/로그아웃 감지)
+  Stream<String?> authUidChanges();
+
+  /// 현재 uid (없으면 null)
+  String? currentUid();
+
+  Future<String> signIn({required String email, required String password});
+  Future<String> signUp({required String email, required String password}); // 선택
+  Future<String> signInWithGoogle(); // ✅ 구글 로그인
+  Future<void> signOut();
+}

--- a/todo_mini/lib/data/repositories/notice_repository.dart
+++ b/todo_mini/lib/data/repositories/notice_repository.dart
@@ -1,0 +1,16 @@
+import '../models/notice.dart';
+
+class NoticeCreateInput {
+  final String title;
+  final String content;
+
+  NoticeCreateInput({required this.title, required this.content});
+}
+
+abstract class NoticeRepository {
+  Stream<List<Notice>> watchNotices();
+
+  // ADMIN
+  Future<void> createNotice(NoticeCreateInput input);
+  Future<void> deleteNotice(String noticeId); // 또는 updateNotice도 가능
+}

--- a/todo_mini/lib/data/repositories/todo_repository.dart
+++ b/todo_mini/lib/data/repositories/todo_repository.dart
@@ -1,0 +1,36 @@
+import '../models/todo.dart';
+
+class TodoCreateInput {
+  final String title;
+  final String? description;
+  final DateTime? dueDate;
+  final String assigneeId;
+
+  TodoCreateInput({
+    required this.title,
+    required this.assigneeId,
+    this.description,
+    this.dueDate,
+  });
+}
+
+/// Todo 데이터 접근 추상화.
+/// 핵심 포인트:
+/// - USER는 "status만 변경"하도록 API를 분리해 1차 방어
+/// - 최종 방어는 Firestore Security Rules에서 필드 제한
+abstract class TodoRepository {
+  // USER
+  Stream<List<Todo>> watchMyTodos(String myUid);
+
+  /// ✅ USER 전용 API: status만 수정 가능
+  Future<void> updateMyTodoStatus({
+    required String todoId,
+    required String myUid,
+    required TodoStatus status,
+  });
+
+  // ADMIN
+  Stream<List<Todo>> watchAllTodos();
+  Future<void> createTodo(TodoCreateInput input);
+  Future<void> deleteTodo(String todoId);
+}

--- a/todo_mini/lib/data/repositories/user_repository.dart
+++ b/todo_mini/lib/data/repositories/user_repository.dart
@@ -1,0 +1,11 @@
+import '../models/app_user.dart';
+
+abstract class UserRepository {
+  /// 로그인 직후 호출: users/{uid}가 없으면 생성하고 반환
+  Future<AppUser> getOrCreateCurrentUser({required String defaultName});
+
+  Future<AppUser> getUserById(String uid);
+
+  /// admin이 assignee 선택할 때 사용
+  Future<List<AppUser>> getUsers();
+}

--- a/todo_mini/lib/data/repositories_impl/auth_repository_impl.dart
+++ b/todo_mini/lib/data/repositories_impl/auth_repository_impl.dart
@@ -1,0 +1,38 @@
+import '../datasources/firebase_auth_ds.dart';
+import '../repositories/auth_repository.dart';
+
+/// AuthRepository 구현체.
+/// - FirebaseAuthDataSource에 위임
+/// - ViewModel에서는 FirebaseAuth를 직접 모르도록 분리
+class AuthRepositoryImpl implements AuthRepository {
+  final FirebaseAuthDataSource _ds;
+
+  AuthRepositoryImpl(this._ds);
+
+  @override
+  Stream<String?> authUidChanges() => _ds.authStateChanges().map((u) => u?.uid);
+
+  @override
+  String? currentUid() => _ds.currentUser?.uid;
+
+  @override
+  Future<String> signIn({required String email, required String password}) async {
+    final cred = await _ds.signIn(email, password);
+    return cred.user!.uid;
+  }
+
+  @override
+  Future<String> signUp({required String email, required String password}) async {
+    final cred = await _ds.signUp(email, password);
+    return cred.user!.uid;
+  }
+
+  @override
+  Future<String> signInWithGoogle() async {
+    final cred = await _ds.signInWithGoogle();
+    return cred.user!.uid;
+  }
+
+  @override
+  Future<void> signOut() => _ds.signOut();
+}

--- a/todo_mini/lib/data/repositories_impl/notice_repository_impl.dart
+++ b/todo_mini/lib/data/repositories_impl/notice_repository_impl.dart
@@ -1,0 +1,33 @@
+import '../datasources/firestore_ds.dart';
+import '../models/notice.dart';
+import '../repositories/notice_repository.dart';
+
+class NoticeRepositoryImpl implements NoticeRepository {
+  final FirestoreDataSource _fs;
+  NoticeRepositoryImpl(this._fs);
+
+  @override
+  Stream<List<Notice>> watchNotices() {
+    return _fs
+        .notices()
+        .orderBy('createdAt', descending: true)
+        .limit(20)
+        .snapshots()
+        .map((s) => s.docs.map(Notice.fromDoc).toList());
+  }
+
+  @override
+  Future<void> createNotice(NoticeCreateInput input) async {
+    await _fs.notices().add({
+      'title': input.title,
+      'content': input.content,
+      'createdAt': _fs.serverTimestamp(),
+      'updatedAt': _fs.serverTimestamp(),
+    });
+  }
+
+  @override
+  Future<void> deleteNotice(String noticeId) async {
+    await _fs.notices().doc(noticeId).delete();
+  }
+}

--- a/todo_mini/lib/data/repositories_impl/todo_repository_impl.dart
+++ b/todo_mini/lib/data/repositories_impl/todo_repository_impl.dart
@@ -1,0 +1,62 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../datasources/firestore_ds.dart';
+import '../models/todo.dart';
+import '../repositories/todo_repository.dart';
+
+class TodoRepositoryImpl implements TodoRepository {
+  final FirestoreDataSource _fs;
+  TodoRepositoryImpl(this._fs);
+
+  @override
+  Stream<List<Todo>> watchMyTodos(String myUid) {
+    // 정렬은 단순화: status + createdAt (인덱스 부담 최소화)
+    return _fs
+        .todos()
+        .where('assigneeId', isEqualTo: myUid)
+        .orderBy('status')
+        .orderBy('createdAt', descending: true)
+        .snapshots()
+        .map((s) => s.docs.map(Todo.fromDoc).toList());
+  }
+
+  @override
+  Future<void> updateMyTodoStatus({
+    required String todoId,
+    required String myUid,
+    required TodoStatus status,
+  }) async {
+    // ✅ USER API는 status만 수정하도록 제한(1차 방어)
+    // 최종 방어는 Firestore rules에서 status/updatedAt만 변경 가능하게 제한해야 함.
+    await _fs.todos().doc(todoId).update({
+      'status': status == TodoStatus.done ? 'done' : 'open',
+      'updatedAt': _fs.serverTimestamp(),
+    });
+  }
+
+  @override
+  Stream<List<Todo>> watchAllTodos() {
+    return _fs
+        .todos()
+        .orderBy('createdAt', descending: true)
+        .snapshots()
+        .map((s) => s.docs.map(Todo.fromDoc).toList());
+  }
+
+  @override
+  Future<void> createTodo(TodoCreateInput input) async {
+    await _fs.todos().add({
+      'title': input.title,
+      'description': input.description,
+      'dueDate': input.dueDate == null ? null : Timestamp.fromDate(input.dueDate!),
+      'status': 'open',
+      'assigneeId': input.assigneeId,
+      'createdAt': _fs.serverTimestamp(),
+      'updatedAt': _fs.serverTimestamp(),
+    });
+  }
+
+  @override
+  Future<void> deleteTodo(String todoId) async {
+    await _fs.todos().doc(todoId).delete();
+  }
+}

--- a/todo_mini/lib/data/repositories_impl/user_repository_impl.dart
+++ b/todo_mini/lib/data/repositories_impl/user_repository_impl.dart
@@ -1,0 +1,47 @@
+import '../datasources/firestore_ds.dart';
+import '../models/app_user.dart';
+import '../repositories/auth_repository.dart';
+import '../repositories/user_repository.dart';
+
+class UserRepositoryImpl implements UserRepository {
+  final FirestoreDataSource _fs;
+  final AuthRepository _auth;
+
+  UserRepositoryImpl(this._fs, this._auth);
+
+  @override
+  Future<AppUser> getOrCreateCurrentUser({required String defaultName}) async {
+    final uid = _auth.currentUid();
+    if (uid == null) throw StateError('Not signed in');
+
+    final ref = _fs.users().doc(uid);
+    final snap = await ref.get();
+
+    if (snap.exists) {
+      return AppUser.fromDoc(snap);
+    }
+
+    // users 문서가 없으면 생성(과제 요구)
+    await ref.set({
+      'name': defaultName,
+      'role': 'user',
+      'createdAt': _fs.serverTimestamp(),
+    });
+
+    final created = await ref.get();
+    return AppUser.fromDoc(created);
+  }
+
+  @override
+  Future<AppUser> getUserById(String uid) async {
+    final snap = await _fs.users().doc(uid).get();
+    if (!snap.exists) throw StateError('User not found');
+    return AppUser.fromDoc(snap);
+  }
+
+  @override
+  Future<List<AppUser>> getUsers() async {
+    final q = await _fs.users().orderBy('createdAt', descending: true).get();
+    return q.docs.map(AppUser.fromDoc).toList();
+  }
+}

--- a/todo_mini/test/data/repositories/auth_repository_impl_test.dart
+++ b/todo_mini/test/data/repositories/auth_repository_impl_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
+import 'package:todo_mini/data/datasources/firebase_auth_ds.dart';
+import 'package:todo_mini/data/repositories_impl/auth_repository_impl.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('AuthRepositoryImpl should emit uid changes', () async {
+    final mockAuth = MockFirebaseAuth();
+    final ds = FirebaseAuthDataSource(mockAuth);
+    final repo = AuthRepositoryImpl(ds);
+
+    // 초기에는 로그아웃 상태일 수 있음(null)
+    final first = await repo.authUidChanges().first;
+    expect(first, isNull);
+  });
+}

--- a/todo_mini/test/data/repositories/notice_repository_impl_test.dart
+++ b/todo_mini/test/data/repositories/notice_repository_impl_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:todo_mini/data/datasources/firestore_ds.dart';
+import 'package:todo_mini/data/repositories/notice_repository.dart';
+import 'package:todo_mini/data/repositories_impl/notice_repository_impl.dart';
+
+void main() {
+  test('NoticeRepositoryImpl.createNotice should create a notice document', () async {
+    final db = FakeFirebaseFirestore();
+    final fs = FirestoreDataSource(db);
+    final repo = NoticeRepositoryImpl(fs);
+
+    await repo.createNotice(NoticeCreateInput(title: 'N', content: 'C'));
+
+    final snap = await db.collection('notices').get();
+    expect(snap.docs.length, 1);
+
+    final data = snap.docs.first.data();
+    expect(data['title'], 'N');
+    expect(data['content'], 'C');
+    expect(data.containsKey('createdAt'), true);
+    expect(data.containsKey('updatedAt'), true);
+  });
+}

--- a/todo_mini/test/data/repositories/todo_repository_impl_test.dart
+++ b/todo_mini/test/data/repositories/todo_repository_impl_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:todo_mini/data/datasources/firestore_ds.dart';
+import 'package:todo_mini/data/models/todo.dart';
+import 'package:todo_mini/data/repositories/todo_repository.dart';
+import 'package:todo_mini/data/repositories_impl/todo_repository_impl.dart';
+
+void main() {
+  test('TodoRepositoryImpl.createTodo should create a document with expected fields', () async {
+    final db = FakeFirebaseFirestore();
+    final fs = FirestoreDataSource(db);
+    final repo = TodoRepositoryImpl(fs);
+
+    await repo.createTodo(
+      TodoCreateInput(title: 'T', assigneeId: 'uid_1', description: 'D'),
+    );
+
+    final snap = await db.collection('todos').get();
+    expect(snap.docs.length, 1);
+
+    final data = snap.docs.first.data();
+    expect(data['title'], 'T');
+    expect(data['assigneeId'], 'uid_1');
+    expect(data['status'], 'open');
+    expect(data.containsKey('createdAt'), true);
+    expect(data.containsKey('updatedAt'), true);
+  });
+
+  test('TodoRepositoryImpl.updateMyTodoStatus should only update status/updatedAt', () async {
+    final db = FakeFirebaseFirestore();
+    final fs = FirestoreDataSource(db);
+    final repo = TodoRepositoryImpl(fs);
+
+    // 문서 미리 생성
+    final doc = await db.collection('todos').add({
+      'title': 'Hello',
+      'description': 'keep',
+      'dueDate': null,
+      'status': 'open',
+      'assigneeId': 'uid_1',
+      'createdAt': DateTime(2026, 2, 1),
+      'updatedAt': DateTime(2026, 2, 1),
+    });
+
+    await repo.updateMyTodoStatus(
+      todoId: doc.id,
+      myUid: 'uid_1',
+      status: TodoStatus.done,
+    );
+
+    final updated = await db.collection('todos').doc(doc.id).get();
+    final data = updated.data()!;
+
+    // status는 변경되어야 함
+    expect(data['status'], 'done');
+
+    // 다른 필드는 변경되지 않아야 함(Repository 정책)
+    expect(data['title'], 'Hello');
+    expect(data['description'], 'keep');
+    expect(data['assigneeId'], 'uid_1');
+  });
+}


### PR DESCRIPTION
# PR: feature/addRepositories

## What
- Repository 인터페이스/구현체를 추가했습니다.
  - AuthRepository (+ Google login)
  - UserRepository
  - TodoRepository (USER status-only update API 포함)
  - NoticeRepository
- Fake/Mock 기반 단위 테스트를 추가했습니다.
  - Firestore: FakeFirebaseFirestore
  - Auth: firebase_auth_mocks

## Why
- MVVM 구조에서 ViewModel이 Firebase SDK(DataSource)에 직접 의존하지 않게 하여
  테스트 가능성/유지보수성을 높이기 위함입니다.
- USER의 todo 수정 범위를 "status만"으로 API 레벨에서 제한하여(1차 방어),
  Security Rules(2차 방어)와 함께 안전한 구조를 만들기 위함입니다.

## How
- Repository는 DataSource를 통해 Firestore/Auth에 접근합니다.
- TodoRepository.updateMyTodoStatus()는 status/updatedAt만 업데이트합니다.
- 테스트는 Firebase initialize 없이도 돌아가도록 fake/mocks로 구성했습니다.

## Test
\`\`\`bash
flutter test
\`\`\`
