### PR TITLE
Feature/add provider di

### DIFF
--- a/todo_mini/lib/app.dart
+++ b/todo_mini/lib/app.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class App extends StatelessWidget {
+  const App({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      title: 'todo_mini',
+      home: Scaffold(
+        body: Center(
+          child: Text('App bootstrapped (DI ready)'),
+        ),
+      ),
+    );
+  }
+}

--- a/todo_mini/lib/main.dart
+++ b/todo_mini/lib/main.dart
@@ -1,122 +1,72 @@
 import 'package:flutter/material.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:provider/provider.dart';
 
-void main() {
-  runApp(const MyApp());
-}
+import 'app.dart';
 
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+// Firebase SDK
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 
-  // This widget is the root of your application.
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
+// DataSources
+import 'data/datasources/firebase_auth_ds.dart';
+import 'data/datasources/firestore_ds.dart';
 
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
+// Repositories (interfaces)
+import 'data/repositories/auth_repository.dart';
+import 'data/repositories/user_repository.dart';
+import 'data/repositories/todo_repository.dart';
+import 'data/repositories/notice_repository.dart';
 
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
+// Repositories (impl)
+import 'data/repositories_impl/auth_repository_impl.dart';
+import 'data/repositories_impl/user_repository_impl.dart';
+import 'data/repositories_impl/todo_repository_impl.dart';
+import 'data/repositories_impl/notice_repository_impl.dart';
 
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp();
 
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
+  runApp(
+    MultiProvider(
+      providers: [
+        // -----------------------------
+        // 1) DataSource (Firebase SDK wrapper)
+        // -----------------------------
+        Provider(
+          create: (_) => FirebaseAuthDataSource(FirebaseAuth.instance),
         ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
-    );
-  }
+        Provider(
+          create: (_) => FirestoreDataSource(FirebaseFirestore.instance),
+        ),
+
+        // -----------------------------
+        // 2) Repository (interface -> impl)
+        // -----------------------------
+        Provider<AuthRepository>(
+          create: (ctx) => AuthRepositoryImpl(
+            ctx.read<FirebaseAuthDataSource>(),
+          ),
+        ),
+        Provider<UserRepository>(
+          create: (ctx) => UserRepositoryImpl(
+            ctx.read<FirestoreDataSource>(),
+            ctx.read<AuthRepository>(),
+          ),
+        ),
+        Provider<TodoRepository>(
+          create: (ctx) => TodoRepositoryImpl(
+            ctx.read<FirestoreDataSource>(),
+          ),
+        ),
+        Provider<NoticeRepository>(
+          create: (ctx) => NoticeRepositoryImpl(
+            ctx.read<FirestoreDataSource>(),
+          ),
+        ),
+      ],
+      child: const App(),
+    ),
+  );
 }

--- a/todo_mini/test/app/provider_wiring_test.dart
+++ b/todo_mini/test/app/provider_wiring_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
+
+import 'package:todo_mini/data/datasources/firebase_auth_ds.dart';
+import 'package:todo_mini/data/datasources/firestore_ds.dart';
+
+import 'package:todo_mini/data/repositories/auth_repository.dart';
+import 'package:todo_mini/data/repositories/user_repository.dart';
+import 'package:todo_mini/data/repositories/todo_repository.dart';
+import 'package:todo_mini/data/repositories/notice_repository.dart';
+
+import 'package:todo_mini/data/repositories_impl/auth_repository_impl.dart';
+import 'package:todo_mini/data/repositories_impl/user_repository_impl.dart';
+import 'package:todo_mini/data/repositories_impl/todo_repository_impl.dart';
+import 'package:todo_mini/data/repositories_impl/notice_repository_impl.dart';
+
+/// Provider wiring이 깨지면 런타임에서 늦게 터질 수 있어서,
+/// "Repo까지 DI가 생성 가능한가"만 확인하는 스모크 테스트를 둡니다.
+/// (ViewModel은 다음 PR들에서 레이어가 생길 때 추가)
+void main() {
+  testWidgets('Provider DI should create datasources and repositories', (tester) async {
+    final mockAuth = MockFirebaseAuth();
+    final fakeDb = FakeFirebaseFirestore();
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          // DataSources (Fake/Mock)
+          Provider(create: (_) => FirebaseAuthDataSource(mockAuth)),
+          Provider(create: (_) => FirestoreDataSource(fakeDb)),
+
+          // Repositories
+          Provider<AuthRepository>(create: (ctx) => AuthRepositoryImpl(ctx.read())),
+          Provider<UserRepository>(create: (ctx) => UserRepositoryImpl(ctx.read(), ctx.read())),
+          Provider<TodoRepository>(create: (ctx) => TodoRepositoryImpl(ctx.read())),
+          Provider<NoticeRepository>(create: (ctx) => NoticeRepositoryImpl(ctx.read())),
+        ],
+        child: const MaterialApp(home: Scaffold(body: SizedBox())),
+      ),
+    );
+
+    // pump 성공 + 위젯 존재 = wiring 성공(생성 중 예외 없었음)
+    expect(find.byType(SizedBox), findsOneWidget);
+  });
+}


### PR DESCRIPTION
# PR: feature/addProviderDI

## What
- MultiProvider 기반 DI 구성 추가
  - DataSource(FirebaseAuth/Firestore) 주입
  - Repository(interface -> impl) 주입
- Provider wiring 스모크 테스트 추가(fake/mocks 기반)
- App placeholder 최소 화면 추가

## Why
- MVVM 구조에서 상위 레이어(ViewModel/Screen)가 Repo만 의존하도록 만들기 위해
  DI 기반을 먼저 구축합니다.
- wiring 오류를 런타임 이전에 테스트로 조기 발견하기 위함입니다.

## How
- main.dart에서 Firebase.initializeApp 이후 MultiProvider로 DataSource/Repo만 등록
- 테스트에서는 FakeFirebaseFirestore/MockFirebaseAuth를 주입해 Firebase 초기화 없이 검증

## Test
\`\`\`bash
flutter test
\`\`\`
