### PR TITLE
Feature/add home bootstrap

### DIFF
--- a/todo_mini/lib/app.dart
+++ b/todo_mini/lib/app.dart
@@ -1,16 +1,39 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'core/ui/widgets/loading_view.dart';
+import 'core/ui/widgets/error_view.dart';
+
+import 'features/home/home_view_model.dart';
+import 'features/home/home_placeholder_screen.dart';
 
 class App extends StatelessWidget {
   const App({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
+    return MaterialApp(
       title: 'todo_mini',
-      home: Scaffold(
-        body: Center(
-          child: Text('App bootstrapped (DI ready)'),
-        ),
+      home: Consumer<HomeViewModel>(
+        builder: (_, vm, __) {
+          if (vm.meState.isLoading) {
+            return const Scaffold(body: LoadingView());
+          }
+
+          if (vm.meState.isSuccess) {
+            return HomePlaceholderScreen(me: vm.meState.data!);
+          }
+
+          // 에러 상태(로그인 필요 포함)
+          return Scaffold(
+            body: ErrorView(
+              title: '로그인이 필요합니다',
+              description: vm.meState.message,
+              // 로그인 화면이 아직 placeholder라 retry는 start() 재호출 정도만 제공
+              onRetry: vm.start,
+            ),
+          );
+        },
       ),
     );
   }

--- a/todo_mini/lib/features/auth/login_placeholder_screen.dart
+++ b/todo_mini/lib/features/auth/login_placeholder_screen.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class LoginPlaceholderScreen extends StatelessWidget {
+  const LoginPlaceholderScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(child: Text('Login Placeholder (next PR: feature/addLogin)')),
+    );
+  }
+}

--- a/todo_mini/lib/features/home/home_placeholder_screen.dart
+++ b/todo_mini/lib/features/home/home_placeholder_screen.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import '../../data/models/app_user.dart';
+
+class HomePlaceholderScreen extends StatelessWidget {
+  final AppUser me;
+
+  const HomePlaceholderScreen({super.key, required this.me});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Home')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Signed in as: ${me.name}'),
+            const SizedBox(height: 8),
+            Text('Role: ${me.role.name}'),
+            const SizedBox(height: 16),
+            const Text(
+              'HomeBootstrap 완료!\n다음 PR에서 Login/Home UI를 본격 구현합니다.',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/todo_mini/lib/features/home/home_view_model.dart
+++ b/todo_mini/lib/features/home/home_view_model.dart
@@ -1,0 +1,74 @@
+import 'dart:async';
+import 'package:flutter/foundation.dart';
+
+import '../../core/ui/async_state.dart';
+import '../../data/models/app_user.dart';
+import '../../data/repositories/auth_repository.dart';
+import '../../data/repositories/user_repository.dart';
+
+/// HomeViewModel의 책임:
+/// 1) 로그인 상태(authUidChanges) 구독
+/// 2) 로그인되어 있으면 users/{uid} 문서 보장(getOrCreateCurrentUser)
+/// 3) role(user/admin) 로딩 → 이후 UI에서 분기 가능
+class HomeViewModel extends ChangeNotifier {
+  final AuthRepository _auth;
+  final UserRepository _users;
+
+  HomeViewModel(this._auth, this._users);
+
+  /// meState 성공이면 현재 사용자(AppUser)가 준비된 상태
+  AsyncState<AppUser> meState = const AsyncState.loading();
+
+  StreamSubscription<String?>? _sub;
+
+  bool get isSignedIn => meState.isSuccess;
+  bool get isAdmin => meState.data?.role == UserRole.admin;
+
+  /// 앱 시작 시 1회 호출.
+  /// auth 상태 변화를 구독해서 로그인/로그아웃에 반응합니다.
+  void start() {
+    _sub?.cancel();
+
+    meState = const AsyncState.loading();
+    notifyListeners();
+
+    _sub = _auth.authUidChanges().listen(
+      (uid) async {
+        if (uid == null) {
+          // 로그아웃 상태(또는 아직 로그인 전)
+          meState = const AsyncState.error(message: '로그인이 필요합니다.');
+          notifyListeners();
+          return;
+        }
+
+        // 로그인 상태면 users 문서 확보
+        await bootstrap();
+      },
+      onError: (e) {
+        meState = AsyncState.error(message: '인증 상태를 확인할 수 없습니다: $e');
+        notifyListeners();
+      },
+    );
+  }
+
+  /// 로그인된 사용자의 users 문서를 가져오거나(없으면 생성) meState에 저장합니다.
+  Future<void> bootstrap() async {
+    meState = const AsyncState.loading();
+    notifyListeners();
+
+    try {
+      final me = await _users.getOrCreateCurrentUser(defaultName: 'New User');
+      meState = AsyncState.success(me);
+      notifyListeners();
+    } catch (e) {
+      meState = AsyncState.error(message: '유저 정보를 불러오지 못했습니다: $e');
+      notifyListeners();
+    }
+  }
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    super.dispose();
+  }
+}

--- a/todo_mini/lib/main.dart
+++ b/todo_mini/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:provider/provider.dart';
+import 'package:todo_mini/features/home/home_view_model.dart';
 
 import 'app.dart';
 
@@ -19,7 +20,6 @@ import 'data/repositories/todo_repository.dart';
 import 'data/repositories/notice_repository.dart';
 
 // Repositories (impl)
-import 'data/repositories_impl/auth_repository_impl.dart';
 import 'data/repositories_impl/user_repository_impl.dart';
 import 'data/repositories_impl/todo_repository_impl.dart';
 import 'data/repositories_impl/notice_repository_impl.dart';
@@ -44,10 +44,11 @@ Future<void> main() async {
         // -----------------------------
         // 2) Repository (interface -> impl)
         // -----------------------------
-        Provider<AuthRepository>(
-          create: (ctx) => AuthRepositoryImpl(
-            ctx.read<FirebaseAuthDataSource>(),
-          ),
+        ChangeNotifierProvider(
+          create: (ctx) => HomeViewModel(
+            ctx.read<AuthRepository>(),
+            ctx.read<UserRepository>(),
+          )..start(),
         ),
         Provider<UserRepository>(
           create: (ctx) => UserRepositoryImpl(

--- a/todo_mini/test/features/home/home_view_model_test.dart
+++ b/todo_mini/test/features/home/home_view_model_test.dart
@@ -1,0 +1,117 @@
+import 'dart:async';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:todo_mini/core/ui/async_state.dart';
+import 'package:todo_mini/data/models/app_user.dart';
+import 'package:todo_mini/features/home/home_view_model.dart';
+import 'package:todo_mini/data/repositories/auth_repository.dart';
+import 'package:todo_mini/data/repositories/user_repository.dart';
+
+class FakeAuthRepository implements AuthRepository {
+  final _controller = StreamController<String?>.broadcast();
+  String? _uid;
+
+  // 테스트 편의: 로그인/로그아웃 이벤트 발행
+  void emitUid(String? uid) {
+    _uid = uid;
+    _controller.add(uid);
+  }
+
+  @override
+  Stream<String?> authUidChanges() => _controller.stream;
+
+  @override
+  String? currentUid() => _uid;
+
+  // 아래 메서드는 이 테스트에서 사용하지 않으므로 throw로 충분
+  @override
+  Future<String> signIn({required String email, required String password}) => throw UnimplementedError();
+  @override
+  Future<String> signUp({required String email, required String password}) => throw UnimplementedError();
+  @override
+  Future<String> signInWithGoogle() => throw UnimplementedError();
+  @override
+  Future<void> signOut() => throw UnimplementedError();
+
+  void dispose() => _controller.close();
+}
+
+class FakeUserRepository implements UserRepository {
+  AppUser? nextUser;
+  Object? nextError;
+
+  @override
+  Future<AppUser> getOrCreateCurrentUser({required String defaultName}) async {
+    if (nextError != null) throw nextError!;
+    return nextUser ??
+        AppUser(
+          id: 'uid_1',
+          name: defaultName,
+          role: UserRole.user,
+          createdAt: DateTime(2026, 2, 10),
+        );
+  }
+
+  @override
+  Future<AppUser> getUserById(String uid) => throw UnimplementedError();
+
+  @override
+  Future<List<AppUser>> getUsers() => throw UnimplementedError();
+}
+
+void main() {
+  test('HomeViewModel should set error when logged out', () async {
+    final auth = FakeAuthRepository();
+    final users = FakeUserRepository();
+    final vm = HomeViewModel(auth, users);
+
+    vm.start();
+    auth.emitUid(null);
+
+    // Stream 처리 시간을 조금 줌
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    expect(vm.meState.status, AsyncStatus.error);
+    expect(vm.meState.message, contains('로그인이 필요'));
+    auth.dispose();
+  });
+
+  test('HomeViewModel should bootstrap user when logged in', () async {
+    final auth = FakeAuthRepository();
+    final users = FakeUserRepository()
+      ..nextUser = AppUser(
+        id: 'uid_1',
+        name: 'Kim',
+        role: UserRole.admin,
+        createdAt: DateTime(2026, 2, 10),
+      );
+
+    final vm = HomeViewModel(auth, users);
+
+    vm.start();
+    auth.emitUid('uid_1');
+
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    expect(vm.meState.status, AsyncStatus.success);
+    expect(vm.meState.data!.name, 'Kim');
+    expect(vm.isAdmin, true);
+
+    auth.dispose();
+  });
+
+  test('HomeViewModel should set error when bootstrap fails', () async {
+    final auth = FakeAuthRepository();
+    final users = FakeUserRepository()..nextError = Exception('boom');
+    final vm = HomeViewModel(auth, users);
+
+    vm.start();
+    auth.emitUid('uid_1');
+
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    expect(vm.meState.status, AsyncStatus.error);
+    expect(vm.meState.message, contains('유저 정보를 불러오지 못했습니다'));
+    auth.dispose();
+  });
+}


### PR DESCRIPTION
# PR: feature/addHomeBootstrap

## What
- HomeViewModel 추가
  - authUidChanges 구독
  - 로그인 시 users/{uid} 문서 getOrCreateCurrentUser로 보장
  - role(user/admin) 로드
- App 진입 분기 추가(HomeViewModel 상태 기반)
- 임시 화면(Login/Home placeholder) 추가
- HomeViewModel 단위 테스트 추가(fake repositories)

## Why
- 이후 화면 구현 전에 "앱 부팅 → 로그인 상태 확인 → 유저 문서 보장" 흐름을 먼저 고정해
  기능 개발이 안정적으로 진행되게 하기 위함입니다.

## How
- HomeViewModel이 인증 상태를 구독하고, 로그인 시 bootstrap을 수행합니다.
- UI는 AsyncState를 기준으로 Loading/Success/Error를 분기합니다.

## Test
\`\`\`bash
flutter test
\`\`\`
