### PR TITLE
Feature/add logout

### DIFF
--- a/todo_mini/lib/features/home/home_placeholder_screen.dart
+++ b/todo_mini/lib/features/home/home_placeholder_screen.dart
@@ -1,15 +1,35 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
 import '../../data/models/app_user.dart';
+import '../../data/repositories/auth_repository.dart';
 
 class HomePlaceholderScreen extends StatelessWidget {
   final AppUser me;
 
   const HomePlaceholderScreen({super.key, required this.me});
 
+  Future<void> _signOut(BuildContext context) async {
+    final auth = context.read<AuthRepository>();
+    await auth.signOut();
+    // 별도 네비게이션 처리는 하지 않습니다.
+    // authUidChanges() 변화 → HomeViewModel이 감지 → App이 LoginScreen으로 분기
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Home')),
+      appBar: AppBar(
+        title: const Text('Home'),
+        actions: [
+          IconButton(
+            key: const Key('btn_logout'),
+            tooltip: 'Logout',
+            onPressed: () => _signOut(context),
+            icon: const Icon(Icons.logout),
+          ),
+        ],
+      ),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(
@@ -20,7 +40,8 @@ class HomePlaceholderScreen extends StatelessWidget {
             Text('Role: ${me.role.name}'),
             const SizedBox(height: 16),
             const Text(
-              'HomeBootstrap 완료!\n다음 PR에서 Login/Home UI를 본격 구현합니다.',
+              'Logout 버튼 클릭 시 AuthRepository.signOut 호출 →\n'
+              'HomeViewModel이 authUidChanges()로 감지하여 로그인 화면으로 분기됩니다.',
             ),
           ],
         ),

--- a/todo_mini/test/features/home/logout_button_test.dart
+++ b/todo_mini/test/features/home/logout_button_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import 'package:todo_mini/data/models/app_user.dart';
+import 'package:todo_mini/data/repositories/auth_repository.dart';
+import 'package:todo_mini/features/home/home_placeholder_screen.dart';
+
+class SpyAuthRepository implements AuthRepository {
+  bool signedOut = false;
+
+  @override
+  Future<void> signOut() async {
+    signedOut = true;
+  }
+
+  // 이 테스트에서 사용하지 않는 메서드
+  @override
+  Stream<String?> authUidChanges() => const Stream.empty();
+  @override
+  String? currentUid() => null;
+  @override
+  Future<String> signIn({required String email, required String password}) => throw UnimplementedError();
+  @override
+  Future<String> signUp({required String email, required String password}) => throw UnimplementedError();
+  @override
+  Future<String> signInWithGoogle() => throw UnimplementedError();
+}
+
+void main() {
+  testWidgets('Logout button should call AuthRepository.signOut', (tester) async {
+    final spy = SpyAuthRepository();
+
+    final me = AppUser(
+      id: 'uid_1',
+      name: 'Kim',
+      role: UserRole.user,
+      createdAt: DateTime(2026, 2, 10),
+    );
+
+    await tester.pumpWidget(
+      Provider<AuthRepository>.value(
+        value: spy,
+        child: MaterialApp(
+          home: HomePlaceholderScreen(me: me),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('btn_logout')));
+    await tester.pump();
+
+    expect(spy.signedOut, true);
+  });
+}


### PR DESCRIPTION
# PR: feature/addLogout

## What
- Home 화면에 Logout 버튼 추가
- AuthRepository.signOut 호출로 로그아웃 수행
- Logout 버튼 동작 테스트 추가(SpyAuthRepository)

## Why
- 로그인 플로우 완성 후, 기본 세션 종료 기능을 빠르게 제공하기 위함

## How
- UI에서 AuthRepository.signOut 호출
- authUidChanges 변화는 HomeViewModel이 감지하고 App이 LoginScreen으로 분기

## Test
```bash
flutter test
