### PR TITLE
Feature/add notices

### DIFF
--- a/todo_mini/lib/features/home/home_placeholder_screen.dart
+++ b/todo_mini/lib/features/home/home_placeholder_screen.dart
@@ -4,6 +4,8 @@ import 'package:provider/provider.dart';
 import '../../data/models/app_user.dart';
 import '../../data/repositories/auth_repository.dart';
 
+import '../notices/notices_screen.dart';
+
 class HomePlaceholderScreen extends StatelessWidget {
   final AppUser me;
 
@@ -12,8 +14,12 @@ class HomePlaceholderScreen extends StatelessWidget {
   Future<void> _signOut(BuildContext context) async {
     final auth = context.read<AuthRepository>();
     await auth.signOut();
-    // 별도 네비게이션 처리는 하지 않습니다.
-    // authUidChanges() 변화 → HomeViewModel이 감지 → App이 LoginScreen으로 분기
+  }
+
+  void _openNotices(BuildContext context) {
+    Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => const NoticesScreen()),
+    );
   }
 
   @override
@@ -39,10 +45,18 @@ class HomePlaceholderScreen extends StatelessWidget {
             const SizedBox(height: 8),
             Text('Role: ${me.role.name}'),
             const SizedBox(height: 16),
-            const Text(
-              'Logout 버튼 클릭 시 AuthRepository.signOut 호출 →\n'
-              'HomeViewModel이 authUidChanges()로 감지하여 로그인 화면으로 분기됩니다.',
+
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                key: const Key('btn_open_notices'),
+                onPressed: () => _openNotices(context),
+                child: const Text('공지사항 보기'),
+              ),
             ),
+
+            const SizedBox(height: 16),
+            const Text('Notices 기능이 연결되었습니다.'),
           ],
         ),
       ),

--- a/todo_mini/lib/features/notices/notice_detail_screen.dart
+++ b/todo_mini/lib/features/notices/notice_detail_screen.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import '../../data/models/notice.dart';
+
+class NoticeDetailScreen extends StatelessWidget {
+  final Notice notice;
+
+  const NoticeDetailScreen({super.key, required this.notice});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Notice Detail')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(notice.title, style: Theme.of(context).textTheme.titleLarge),
+            const SizedBox(height: 12),
+            Text(
+              notice.content,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/todo_mini/lib/features/notices/notices_screen.dart
+++ b/todo_mini/lib/features/notices/notices_screen.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../core/ui/widgets/empty_view.dart';
+import '../../core/ui/widgets/error_view.dart';
+import '../../core/ui/widgets/loading_view.dart';
+
+import '../../data/models/notice.dart';
+import 'notices_view_model.dart';
+import 'notice_detail_screen.dart';
+
+class NoticesScreen extends StatelessWidget {
+  const NoticesScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<NoticesViewModel>(
+      builder: (_, vm, __) {
+        final s = vm.state;
+
+        Widget body;
+        if (s.isLoading) {
+          body = const LoadingView();
+        } else if (s.isEmpty) {
+          body = EmptyView(
+            title: '공지사항이 없습니다',
+            description: '관리자가 공지를 등록하면 여기에 표시됩니다.',
+            onRetry: vm.retry,
+          );
+        } else if (s.isError) {
+          body = ErrorView(
+            description: s.message,
+            onRetry: vm.retry,
+          );
+        } else {
+          final items = s.data!;
+          body = ListView.separated(
+            itemCount: items.length,
+            separatorBuilder: (_, __) => const Divider(height: 1),
+            itemBuilder: (_, i) => _NoticeTile(notice: items[i]),
+          );
+        }
+
+        return Scaffold(
+          appBar: AppBar(title: const Text('Notices')),
+          body: body,
+        );
+      },
+    );
+  }
+}
+
+class _NoticeTile extends StatelessWidget {
+  final Notice notice;
+
+  const _NoticeTile({required this.notice});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Text(
+        notice.title,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Text(
+        notice.content,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      onTap: () {
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (_) => NoticeDetailScreen(notice: notice),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/todo_mini/lib/features/notices/notices_view_model.dart
+++ b/todo_mini/lib/features/notices/notices_view_model.dart
@@ -1,0 +1,50 @@
+import 'dart:async';
+import 'package:flutter/foundation.dart';
+
+import '../../core/ui/async_state.dart';
+import '../../data/models/notice.dart';
+import '../../data/repositories/notice_repository.dart';
+
+/// NoticesViewModel 책임:
+/// - NoticeRepository.watchNotices() 스트림 구독
+/// - loading/empty/error/success 상태를 AsyncState로 표준화
+class NoticesViewModel extends ChangeNotifier {
+  final NoticeRepository _repo;
+
+  NoticesViewModel(this._repo);
+
+  AsyncState<List<Notice>> state = const AsyncState.loading();
+
+  StreamSubscription<List<Notice>>? _sub;
+
+  void start() {
+    // 중복 구독 방지
+    _sub?.cancel();
+
+    state = const AsyncState.loading();
+    notifyListeners();
+
+    _sub = _repo.watchNotices().listen(
+      (items) {
+        if (items.isEmpty) {
+          state = const AsyncState.empty();
+        } else {
+          state = AsyncState.success(items);
+        }
+        notifyListeners();
+      },
+      onError: (e) {
+        state = AsyncState.error(message: '공지 로딩 실패: $e');
+        notifyListeners();
+      },
+    );
+  }
+
+  void retry() => start();
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    super.dispose();
+  }
+}

--- a/todo_mini/lib/main.dart
+++ b/todo_mini/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:provider/provider.dart';
 import 'package:todo_mini/features/auth/login_view_model.dart';
 import 'package:todo_mini/features/home/home_view_model.dart';
+import 'package:todo_mini/features/notices/notices_view_model.dart';
 
 import 'app.dart';
 
@@ -23,7 +24,6 @@ import 'data/repositories/notice_repository.dart';
 // Repositories (impl)
 import 'data/repositories_impl/user_repository_impl.dart';
 import 'data/repositories_impl/todo_repository_impl.dart';
-import 'data/repositories_impl/notice_repository_impl.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -45,9 +45,7 @@ Future<void> main() async {
           create: (_) => FirestoreDataSource(FirebaseFirestore.instance),
         ),
 
-        // -----------------------------
-        // 2) Repository (interface -> impl)
-        // -----------------------------
+
         ChangeNotifierProvider(
           create: (ctx) => HomeViewModel(
             ctx.read<AuthRepository>(),
@@ -65,10 +63,8 @@ Future<void> main() async {
             ctx.read<FirestoreDataSource>(),
           ),
         ),
-        Provider<NoticeRepository>(
-          create: (ctx) => NoticeRepositoryImpl(
-            ctx.read<FirestoreDataSource>(),
-          ),
+        ChangeNotifierProvider(
+          create: (ctx) => NoticesViewModel(ctx.read<NoticeRepository>())..start(),
         ),
       ],
       child: const App(),

--- a/todo_mini/test/features/notices/notices_screen_test.dart
+++ b/todo_mini/test/features/notices/notices_screen_test.dart
@@ -1,0 +1,49 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import 'package:todo_mini/data/models/notice.dart';
+import 'package:todo_mini/data/repositories/notice_repository.dart';
+import 'package:todo_mini/features/notices/notices_screen.dart';
+import 'package:todo_mini/features/notices/notices_view_model.dart';
+
+class FakeNoticeRepository implements NoticeRepository {
+  final controller = StreamController<List<Notice>>.broadcast();
+
+  @override
+  Stream<List<Notice>> watchNotices() => controller.stream;
+
+  @override
+  Future<void> createNotice(NoticeCreateInput input) => throw UnimplementedError();
+  @override
+  Future<void> deleteNotice(String noticeId) => throw UnimplementedError();
+
+  void dispose() => controller.close();
+}
+
+void main() {
+  testWidgets('NoticesScreen shows empty view when no notices', (tester) async {
+    final repo = FakeNoticeRepository();
+    final vm = NoticesViewModel(repo)..start();
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          Provider<NoticeRepository>.value(value: repo),
+          ChangeNotifierProvider<NoticesViewModel>.value(value: vm),
+        ],
+        child: const MaterialApp(home: NoticesScreen()),
+      ),
+    );
+
+    // stream이 아직 안 왔으니 loading일 수 있음 → 빈 리스트 발행
+    repo.controller.add([]);
+    await tester.pump(const Duration(milliseconds: 10));
+
+    expect(find.text('공지사항이 없습니다'), findsOneWidget);
+
+    repo.dispose();
+  });
+}

--- a/todo_mini/test/features/notices/notices_view_model_test.dart
+++ b/todo_mini/test/features/notices/notices_view_model_test.dart
@@ -1,0 +1,72 @@
+import 'dart:async';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:todo_mini/core/ui/async_state.dart';
+import 'package:todo_mini/data/models/notice.dart';
+import 'package:todo_mini/data/repositories/notice_repository.dart';
+import 'package:todo_mini/features/notices/notices_view_model.dart';
+
+class FakeNoticeRepository implements NoticeRepository {
+  final controller = StreamController<List<Notice>>.broadcast();
+
+  @override
+  Stream<List<Notice>> watchNotices() => controller.stream;
+
+  // admin 메서드는 이 테스트에서 사용하지 않음
+  @override
+  Future<void> createNotice(NoticeCreateInput input) => throw UnimplementedError();
+  @override
+  Future<void> deleteNotice(String noticeId) => throw UnimplementedError();
+
+  void dispose() => controller.close();
+}
+
+void main() {
+  test('NoticesViewModel should become empty when stream emits empty list', () async {
+    final repo = FakeNoticeRepository();
+    final vm = NoticesViewModel(repo);
+
+    vm.start();
+    repo.controller.add([]);
+
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    expect(vm.state.status, AsyncStatus.empty);
+
+    repo.dispose();
+  });
+
+  test('NoticesViewModel should become success when stream emits items', () async {
+    final repo = FakeNoticeRepository();
+    final vm = NoticesViewModel(repo);
+
+    vm.start();
+    repo.controller.add([
+      Notice(
+        id: 'n1',
+        title: 't',
+        content: 'c',
+        createdAt: DateTime(2026, 2, 10),
+        updatedAt: DateTime(2026, 2, 10),
+      ),
+    ]);
+
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    expect(vm.state.status, AsyncStatus.success);
+    expect(vm.state.data!.length, 1);
+
+    repo.dispose();
+  });
+
+  test('NoticesViewModel should become error on stream error', () async {
+    final repo = FakeNoticeRepository();
+    final vm = NoticesViewModel(repo);
+
+    vm.start();
+    repo.controller.addError(Exception('boom'));
+
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    expect(vm.state.status, AsyncStatus.error);
+
+    repo.dispose();
+  });
+}


### PR DESCRIPTION
# PR: feature/addNotices

## What
- NoticesViewModel 추가(Stream 구독 + AsyncState)
- 공지 목록 화면(NoticesScreen) + 공지 상세(NoticeDetailScreen) 추가
- Home에서 "공지사항 보기" 버튼으로 진입 가능
- 단위/위젯 테스트 추가

## Why
- 사용자 기능(공지 조회)을 먼저 연결해 데모 흐름을 완성하기 위함
- 스트림 기반 데이터 로딩의 loading/empty/error 패턴을 표준화하기 위함

## How
- NoticeRepository.watchNotices() 구독 결과를 AsyncState로 변환하여 UI 렌더링
- Home → NoticesScreen 네비게이션 추가

## Test
```bash
flutter test
