### PR TITLE
Feature/add my todos

### DIFF
--- a/todo_mini/lib/features/home/home_placeholder_screen.dart
+++ b/todo_mini/lib/features/home/home_placeholder_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:todo_mini/features/todos/my_todos_screen.dart';
 
 import '../../data/models/app_user.dart';
 import '../../data/repositories/auth_repository.dart';
@@ -52,6 +53,19 @@ class HomePlaceholderScreen extends StatelessWidget {
                 key: const Key('btn_open_notices'),
                 onPressed: () => _openNotices(context),
                 child: const Text('공지사항 보기'),
+              ),
+            ),
+
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                key: const Key('btn_open_my_todos'),
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(builder: (_) => const MyTodosScreen()),
+                  );
+                },
+                child: const Text('내 할 일 보기'),
               ),
             ),
 

--- a/todo_mini/lib/features/todos/my_todos_screen.dart
+++ b/todo_mini/lib/features/todos/my_todos_screen.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../core/ui/widgets/empty_view.dart';
+import '../../core/ui/widgets/error_view.dart';
+import '../../core/ui/widgets/loading_view.dart';
+import '../../data/models/todo.dart';
+
+import '../home/home_view_model.dart';
+import 'my_todos_view_model.dart';
+import 'todo_detail_screen.dart';
+
+class MyTodosScreen extends StatefulWidget {
+  const MyTodosScreen({super.key});
+
+  @override
+  State<MyTodosScreen> createState() => _MyTodosScreenState();
+}
+
+class _MyTodosScreenState extends State<MyTodosScreen> {
+  bool _started = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+
+    // HomeViewModel에서 me가 준비된 후에만 start 호출
+    if (_started) return;
+    final homeVm = context.read<HomeViewModel>();
+    if (homeVm.meState.isSuccess) {
+      final myUid = homeVm.meState.data!.id;
+      context.read<MyTodosViewModel>().start(myUid: myUid);
+      _started = true;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<MyTodosViewModel>(
+      builder: (_, vm, __) {
+        final s = vm.state;
+
+        Widget body;
+        if (s.isLoading) {
+          body = const LoadingView();
+        } else if (s.isEmpty) {
+          body = EmptyView(
+            title: '내 할 일이 없습니다',
+            description: '관리자가 할 일을 배정하면 여기에 표시됩니다.',
+            onRetry: vm.retry,
+          );
+        } else if (s.isError) {
+          body = ErrorView(
+            description: s.message,
+            onRetry: vm.retry,
+          );
+        } else {
+          final items = s.data!;
+          body = ListView.separated(
+            itemCount: items.length,
+            separatorBuilder: (_, __) => const Divider(height: 1),
+            itemBuilder: (_, i) => _TodoTile(todo: items[i]),
+          );
+        }
+
+        return Scaffold(
+          appBar: AppBar(title: const Text('My Todos')),
+          body: body,
+        );
+      },
+    );
+  }
+}
+
+class _TodoTile extends StatelessWidget {
+  final Todo todo;
+
+  const _TodoTile({required this.todo});
+
+  @override
+  Widget build(BuildContext context) {
+    final isDone = todo.status == TodoStatus.done;
+
+    return ListTile(
+      title: Text(
+        todo.title,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Text(isDone ? 'DONE' : 'OPEN'),
+      trailing: Icon(isDone ? Icons.check_circle : Icons.circle_outlined),
+      onTap: () {
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (_) => TodoDetailScreen(todo: todo),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/todo_mini/lib/features/todos/my_todos_view_model.dart
+++ b/todo_mini/lib/features/todos/my_todos_view_model.dart
@@ -1,0 +1,58 @@
+import 'dart:async';
+import 'package:flutter/foundation.dart';
+
+import '../../core/ui/async_state.dart';
+import '../../data/models/todo.dart';
+import '../../data/repositories/todo_repository.dart';
+
+/// MyTodosViewModel 책임:
+/// - 내 todo 스트림 구독
+/// - 리스트 상태(loading/empty/error/success) 관리
+class MyTodosViewModel extends ChangeNotifier {
+  final TodoRepository _repo;
+
+  MyTodosViewModel(this._repo);
+
+  AsyncState<List<Todo>> state = const AsyncState.loading();
+  StreamSubscription<List<Todo>>? _sub;
+
+  String? _myUid;
+
+  /// 내 uid가 정해진 뒤에 start를 호출해야 합니다.
+  /// - HomeBootstrap 성공 후(me.id) 화면에서 호출하는 구조가 깔끔합니다.
+  void start({required String myUid}) {
+    if (_myUid == myUid && _sub != null) return;
+
+    _myUid = myUid;
+    _sub?.cancel();
+
+    state = const AsyncState.loading();
+    notifyListeners();
+
+    _sub = _repo.watchMyTodos(myUid).listen(
+      (items) {
+        if (items.isEmpty) {
+          state = const AsyncState.empty();
+        } else {
+          state = AsyncState.success(items);
+        }
+        notifyListeners();
+      },
+      onError: (e) {
+        state = AsyncState.error(message: '내 할 일 로딩 실패: $e');
+        notifyListeners();
+      },
+    );
+  }
+
+  void retry() {
+    final uid = _myUid;
+    if (uid != null) start(myUid: uid);
+  }
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    super.dispose();
+  }
+}

--- a/todo_mini/lib/features/todos/todo_detail_screen.dart
+++ b/todo_mini/lib/features/todos/todo_detail_screen.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../core/ui/widgets/error_view.dart';
+import '../../core/ui/widgets/loading_view.dart';
+import '../../data/models/todo.dart';
+
+import '../home/home_view_model.dart';
+import 'todo_detail_view_model.dart';
+
+class TodoDetailScreen extends StatelessWidget {
+  final Todo todo;
+
+  const TodoDetailScreen({super.key, required this.todo});
+
+  @override
+  Widget build(BuildContext context) {
+    final myUid = context.read<HomeViewModel>().meState.data!.id;
+
+    return ChangeNotifierProvider(
+      create: (ctx) => TodoDetailViewModel(ctx.read()),
+      child: Consumer<TodoDetailViewModel>(
+        builder: (_, vm, __) {
+          final s = vm.state;
+
+          return Scaffold(
+            appBar: AppBar(title: const Text('Todo Detail')),
+            body: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(todo.title, style: Theme.of(context).textTheme.titleLarge),
+                  const SizedBox(height: 8),
+                  Text(todo.description ?? '-'),
+                  const SizedBox(height: 16),
+
+                  Text('Current status: ${todo.status.name.toUpperCase()}'),
+
+                  const SizedBox(height: 16),
+
+                  if (s.isLoading) const LoadingView(message: '업데이트 중...'),
+                  if (s.isError)
+                    ErrorView(
+                      title: '실패',
+                      description: s.message,
+                      onRetry: vm.resetError,
+                    ),
+
+                  const Spacer(),
+
+                  SizedBox(
+                    width: double.infinity,
+                    child: ElevatedButton(
+                      key: const Key('btn_toggle_status'),
+                      onPressed: s.isLoading
+                          ? null
+                          : () => vm.toggleStatus(todo: todo, myUid: myUid),
+                      child: Text(
+                        todo.status == TodoStatus.done ? 'DONE → OPEN' : 'OPEN → DONE',
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/todo_mini/lib/features/todos/todo_detail_view_model.dart
+++ b/todo_mini/lib/features/todos/todo_detail_view_model.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/foundation.dart';
+
+import '../../core/ui/async_state.dart';
+import '../../data/models/todo.dart';
+import '../../data/repositories/todo_repository.dart';
+
+/// TodoDetailViewModel 책임:
+/// - status 토글 요청 처리
+/// - USER는 status만 업데이트하도록 repository API 사용
+class TodoDetailViewModel extends ChangeNotifier {
+  final TodoRepository _repo;
+
+  TodoDetailViewModel(this._repo);
+
+  AsyncState<void> state = const AsyncState.idle();
+
+  Future<void> toggleStatus({
+    required Todo todo,
+    required String myUid,
+  }) async {
+    state = const AsyncState.loading();
+    notifyListeners();
+
+    try {
+      await _repo.updateMyTodoStatus(
+        todoId: todo.id,
+        myUid: myUid,
+        status: todo.toggledStatus,
+      );
+      state = const AsyncState.success(null);
+      notifyListeners();
+    } catch (e) {
+      state = AsyncState.error(message: '상태 변경 실패: $e');
+      notifyListeners();
+    }
+  }
+
+  void resetError() {
+    if (state.isError) {
+      state = const AsyncState.idle();
+      notifyListeners();
+    }
+  }
+}

--- a/todo_mini/test/features/todos/my_todos_view_model_test.dart
+++ b/todo_mini/test/features/todos/my_todos_view_model_test.dart
@@ -1,0 +1,74 @@
+import 'dart:async';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:todo_mini/core/ui/async_state.dart';
+import 'package:todo_mini/data/models/todo.dart';
+import 'package:todo_mini/data/repositories/todo_repository.dart';
+import 'package:todo_mini/features/todos/my_todos_view_model.dart';
+
+class FakeTodoRepository implements TodoRepository {
+  final controller = StreamController<List<Todo>>.broadcast();
+  TodoStatus? lastUpdatedStatus;
+
+  @override
+  Stream<List<Todo>> watchMyTodos(String myUid) => controller.stream;
+
+  @override
+  Future<void> updateMyTodoStatus({
+    required String todoId,
+    required String myUid,
+    required TodoStatus status,
+  }) async {
+    lastUpdatedStatus = status;
+  }
+
+  // admin 메서드는 이 테스트에서 사용하지 않음
+  @override
+  Stream<List<Todo>> watchAllTodos() => throw UnimplementedError();
+  @override
+  Future<void> createTodo(TodoCreateInput input) => throw UnimplementedError();
+  @override
+  Future<void> deleteTodo(String todoId) => throw UnimplementedError();
+
+  void dispose() => controller.close();
+}
+
+void main() {
+  test('MyTodosViewModel becomes empty when stream emits empty', () async {
+    final repo = FakeTodoRepository();
+    final vm = MyTodosViewModel(repo);
+
+    vm.start(myUid: 'uid_1');
+    repo.controller.add([]);
+
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    expect(vm.state.status, AsyncStatus.empty);
+
+    repo.dispose();
+  });
+
+  test('MyTodosViewModel becomes success when stream emits items', () async {
+    final repo = FakeTodoRepository();
+    final vm = MyTodosViewModel(repo);
+
+    vm.start(myUid: 'uid_1');
+    repo.controller.add([
+      Todo(
+        id: 't1',
+        title: 'A',
+        description: null,
+        dueDate: null,
+        status: TodoStatus.open,
+        assigneeId: 'uid_1',
+        createdAt: DateTime(2026, 2, 10),
+        updatedAt: DateTime(2026, 2, 10),
+      ),
+    ]);
+
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    expect(vm.state.status, AsyncStatus.success);
+    expect(vm.state.data!.length, 1);
+
+    repo.dispose();
+  });
+}

--- a/todo_mini/test/features/todos/todo_detail_view_model_test.dart
+++ b/todo_mini/test/features/todos/todo_detail_view_model_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:todo_mini/core/ui/async_state.dart';
+import 'package:todo_mini/data/models/todo.dart';
+import 'package:todo_mini/data/repositories/todo_repository.dart';
+import 'package:todo_mini/features/todos/todo_detail_view_model.dart';
+
+class SpyTodoRepository implements TodoRepository {
+  TodoStatus? updatedTo;
+
+  @override
+  Future<void> updateMyTodoStatus({
+    required String todoId,
+    required String myUid,
+    required TodoStatus status,
+  }) async {
+    updatedTo = status;
+  }
+
+  // 나머지 메서드는 사용 안 함
+  @override
+  Stream<List<Todo>> watchMyTodos(String myUid) => const Stream.empty();
+  @override
+  Stream<List<Todo>> watchAllTodos() => throw UnimplementedError();
+  @override
+  Future<void> createTodo(TodoCreateInput input) => throw UnimplementedError();
+  @override
+  Future<void> deleteTodo(String todoId) => throw UnimplementedError();
+}
+
+void main() {
+  test('TodoDetailViewModel toggles status via status-only API', () async {
+    final repo = SpyTodoRepository();
+    final vm = TodoDetailViewModel(repo);
+
+    final todo = Todo(
+      id: 't1',
+      title: 'A',
+      description: null,
+      dueDate: null,
+      status: TodoStatus.open,
+      assigneeId: 'uid_1',
+      createdAt: DateTime(2026, 2, 10),
+      updatedAt: DateTime(2026, 2, 10),
+    );
+
+    await vm.toggleStatus(todo: todo, myUid: 'uid_1');
+
+    expect(vm.state.status, AsyncStatus.success);
+    expect(repo.updatedTo, TodoStatus.done);
+  });
+}


### PR DESCRIPTION
# PR: feature/addMyTodos

## What
- MyTodosViewModel 추가(내 todo 스트림 구독 + AsyncState)
- 내 할 일 목록 화면(MyTodosScreen) + 상세(TodoDetailScreen) 추가
- 상세 화면에서 status 토글 기능 추가(USER status-only API 사용)
- Home에서 "내 할 일 보기" 버튼 추가
- 단위 테스트 추가(MyTodosViewModel / TodoDetailViewModel)

## Why
- 사용자 플로우(공지 확인 → 내 할 일 확인/처리)를 완성하기 위함
- USER가 수정 가능한 범위를 status만으로 제한하는 구조를 UI까지 일관되게 연결하기 위함

## How
- TodoRepository.watchMyTodos() 스트림을 AsyncState로 변환해 UI 렌더링
- 상태 변경은 TodoRepository.updateMyTodoStatus()만 사용

## Test
```bash
flutter test
