### PR TITLE
Feature/add admin

### DIFF
--- a/todo_mini/lib/features/admin/admin_screen.dart
+++ b/todo_mini/lib/features/admin/admin_screen.dart
@@ -1,0 +1,242 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../core/ui/widgets/loading_view.dart';
+import '../../core/ui/widgets/empty_view.dart';
+import '../../core/ui/widgets/error_view.dart';
+
+import '../../data/models/app_user.dart';
+import '../../data/models/todo.dart';
+import '../../data/models/notice.dart';
+
+import '../../data/repositories/user_repository.dart';
+import '../../data/repositories/todo_repository.dart';
+import '../../data/repositories/notice_repository.dart';
+
+import 'admin_view_model.dart';
+import 'create_todo_dialog.dart';
+import 'create_notice_dialog.dart';
+
+class AdminScreen extends StatelessWidget {
+  const AdminScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider(
+      create: (ctx) => AdminViewModel(
+        ctx.read<UserRepository>(),
+        ctx.read<TodoRepository>(),
+        ctx.read<NoticeRepository>(),
+      )..start(),
+      child: Consumer<AdminViewModel>(
+        builder: (_, vm, __) {
+          final action = vm.actionState;
+
+          return Scaffold(
+            appBar: AppBar(
+              title: const Text('Admin'),
+              actions: [
+                IconButton(
+                  key: const Key('btn_admin_add_todo'),
+                  tooltip: 'Add Todo',
+                  onPressed: () async {
+                    final users = vm.usersState.data ?? <AppUser>[];
+                    await showDialog(
+                      context: context,
+                      builder: (_) => CreateTodoDialog(
+                        users: users,
+                        onSubmit: (title, desc, due, assigneeId) async {
+                          await vm.createTodo(
+                            title: title,
+                            description: desc,
+                            dueDate: due,
+                            assigneeId: assigneeId,
+                          );
+                        },
+                      ),
+                    );
+                  },
+                  icon: const Icon(Icons.add_task),
+                ),
+                IconButton(
+                  key: const Key('btn_admin_add_notice'),
+                  tooltip: 'Add Notice',
+                  onPressed: () async {
+                    await showDialog(
+                      context: context,
+                      builder: (_) => CreateNoticeDialog(
+                        onSubmit: (title, content) async {
+                          await vm.createNotice(title: title, content: content);
+                        },
+                      ),
+                    );
+                  },
+                  icon: const Icon(Icons.campaign),
+                ),
+              ],
+            ),
+            body: Column(
+              children: [
+                if (action.isLoading)
+                  const Padding(
+                    padding: EdgeInsets.all(12),
+                    child: LoadingView(message: '처리 중...'),
+                  ),
+                if (action.isError)
+                  Padding(
+                    padding: const EdgeInsets.all(12),
+                    child: ErrorView(
+                      title: '작업 실패',
+                      description: action.message,
+                      onRetry: vm.resetActionState,
+                    ),
+                  ),
+
+                Expanded(
+                  child: ListView(
+                    padding: const EdgeInsets.all(16),
+                    children: [
+                      _SectionTitle(
+                        title: 'Users',
+                        onRefresh: vm.loadUsers,
+                      ),
+                      _UsersSection(state: vm.usersState),
+
+                      const SizedBox(height: 24),
+
+                      const _SectionTitle(title: 'Todos'),
+                      _TodosSection(
+                        state: vm.todosState,
+                        onDelete: vm.deleteTodo,
+                      ),
+
+                      const SizedBox(height: 24),
+
+                      const _SectionTitle(title: 'Notices'),
+                      _NoticesSection(
+                        state: vm.noticesState,
+                        onDelete: vm.deleteNotice,
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _SectionTitle extends StatelessWidget {
+  final String title;
+  final Future<void> Function()? onRefresh;
+
+  const _SectionTitle({required this.title, this.onRefresh});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Text(title, style: Theme.of(context).textTheme.titleMedium),
+        const Spacer(),
+        if (onRefresh != null)
+          IconButton(
+            onPressed: onRefresh,
+            icon: const Icon(Icons.refresh),
+          ),
+      ],
+    );
+  }
+}
+
+class _UsersSection extends StatelessWidget {
+  final state;
+
+  const _UsersSection({required this.state});
+
+  @override
+  Widget build(BuildContext context) {
+    if (state.isLoading) return const LoadingView();
+    if (state.isEmpty) return const EmptyView(title: '유저가 없습니다');
+    if (state.isError) return ErrorView(description: state.message);
+
+    final List<AppUser> users = state.data!;
+    return Column(
+      children: users
+          .map(
+            (u) => ListTile(
+              dense: true,
+              title: Text(u.name),
+              subtitle: Text('role: ${u.role.name} / uid: ${u.id}'),
+            ),
+          )
+          .toList(),
+    );
+  }
+}
+
+class _TodosSection extends StatelessWidget {
+  final state;
+  final Future<void> Function(String todoId) onDelete;
+
+  const _TodosSection({required this.state, required this.onDelete});
+
+  @override
+  Widget build(BuildContext context) {
+    if (state.isLoading) return const LoadingView();
+    if (state.isEmpty) return const EmptyView(title: 'Todo가 없습니다');
+    if (state.isError) return ErrorView(description: state.message);
+
+    final List<Todo> items = state.data!;
+    return Column(
+      children: items
+          .map(
+            (t) => ListTile(
+              dense: true,
+              title: Text(t.title),
+              subtitle: Text('assignee: ${t.assigneeId} / status: ${t.status.name}'),
+              trailing: IconButton(
+                key: Key('btn_delete_todo_${t.id}'),
+                icon: const Icon(Icons.delete),
+                onPressed: () => onDelete(t.id),
+              ),
+            ),
+          )
+          .toList(),
+    );
+  }
+}
+
+class _NoticesSection extends StatelessWidget {
+  final state;
+  final Future<void> Function(String noticeId) onDelete;
+
+  const _NoticesSection({required this.state, required this.onDelete});
+
+  @override
+  Widget build(BuildContext context) {
+    if (state.isLoading) return const LoadingView();
+    if (state.isEmpty) return const EmptyView(title: '공지사항이 없습니다');
+    if (state.isError) return ErrorView(description: state.message);
+
+    final List<Notice> items = state.data!;
+    return Column(
+      children: items
+          .map(
+            (n) => ListTile(
+              dense: true,
+              title: Text(n.title),
+              subtitle: Text(n.content, maxLines: 1, overflow: TextOverflow.ellipsis),
+              trailing: IconButton(
+                key: Key('btn_delete_notice_${n.id}'),
+                icon: const Icon(Icons.delete),
+                onPressed: () => onDelete(n.id),
+              ),
+            ),
+          )
+          .toList(),
+    );
+  }
+}

--- a/todo_mini/lib/features/admin/admin_view_model.dart
+++ b/todo_mini/lib/features/admin/admin_view_model.dart
@@ -1,0 +1,171 @@
+import 'dart:async';
+import 'package:flutter/foundation.dart';
+
+import '../../core/ui/async_state.dart';
+import '../../data/models/app_user.dart';
+import '../../data/models/todo.dart';
+import '../../data/models/notice.dart';
+
+import '../../data/repositories/user_repository.dart';
+import '../../data/repositories/todo_repository.dart';
+import '../../data/repositories/notice_repository.dart';
+
+/// AdminViewModel 책임:
+/// - admin 화면에서 필요한 데이터 스트림/리스트 로딩
+/// - create/delete 같은 액션 처리
+///
+/// NOTE:
+/// - users는 "목록 한번 로딩" (stream 필요 없음)
+/// - todos/notices는 stream 기반으로 실시간 반영
+class AdminViewModel extends ChangeNotifier {
+  final UserRepository _users;
+  final TodoRepository _todos;
+  final NoticeRepository _notices;
+
+  AdminViewModel(this._users, this._todos, this._notices);
+
+  AsyncState<List<AppUser>> usersState = const AsyncState.loading();
+  AsyncState<List<Todo>> todosState = const AsyncState.loading();
+  AsyncState<List<Notice>> noticesState = const AsyncState.loading();
+
+  AsyncState<void> actionState = const AsyncState.idle();
+
+  StreamSubscription<List<Todo>>? _todoSub;
+  StreamSubscription<List<Notice>>? _noticeSub;
+
+  Future<void> start() async {
+    await loadUsers();
+    watchTodos();
+    watchNotices();
+  }
+
+  Future<void> loadUsers() async {
+    usersState = const AsyncState.loading();
+    notifyListeners();
+
+    try {
+      final list = await _users.getUsers();
+      usersState = list.isEmpty ? const AsyncState.empty() : AsyncState.success(list);
+      notifyListeners();
+    } catch (e) {
+      usersState = AsyncState.error(message: '유저 로딩 실패: $e');
+      notifyListeners();
+    }
+  }
+
+  void watchTodos() {
+    _todoSub?.cancel();
+    todosState = const AsyncState.loading();
+    notifyListeners();
+
+    _todoSub = _todos.watchAllTodos().listen(
+      (items) {
+        todosState = items.isEmpty ? const AsyncState.empty() : AsyncState.success(items);
+        notifyListeners();
+      },
+      onError: (e) {
+        todosState = AsyncState.error(message: '전체 할 일 로딩 실패: $e');
+        notifyListeners();
+      },
+    );
+  }
+
+  void watchNotices() {
+    _noticeSub?.cancel();
+    noticesState = const AsyncState.loading();
+    notifyListeners();
+
+    _noticeSub = _notices.watchNotices().listen(
+      (items) {
+        noticesState = items.isEmpty ? const AsyncState.empty() : AsyncState.success(items);
+        notifyListeners();
+      },
+      onError: (e) {
+        noticesState = AsyncState.error(message: '공지 로딩 실패: $e');
+        notifyListeners();
+      },
+    );
+  }
+
+  Future<void> createTodo({
+    required String title,
+    String? description,
+    DateTime? dueDate,
+    required String assigneeId,
+  }) async {
+    actionState = const AsyncState.loading();
+    notifyListeners();
+
+    try {
+      await _todos.createTodo(
+        TodoCreateInput(
+          title: title,
+          description: description,
+          dueDate: dueDate,
+          assigneeId: assigneeId,
+        ),
+      );
+      actionState = const AsyncState.success(null);
+      notifyListeners();
+    } catch (e) {
+      actionState = AsyncState.error(message: '할 일 생성 실패: $e');
+      notifyListeners();
+    }
+  }
+
+  Future<void> deleteTodo(String todoId) async {
+    actionState = const AsyncState.loading();
+    notifyListeners();
+
+    try {
+      await _todos.deleteTodo(todoId);
+      actionState = const AsyncState.success(null);
+      notifyListeners();
+    } catch (e) {
+      actionState = AsyncState.error(message: '할 일 삭제 실패: $e');
+      notifyListeners();
+    }
+  }
+
+  Future<void> createNotice({required String title, required String content}) async {
+    actionState = const AsyncState.loading();
+    notifyListeners();
+
+    try {
+      await _notices.createNotice(NoticeCreateInput(title: title, content: content));
+      actionState = const AsyncState.success(null);
+      notifyListeners();
+    } catch (e) {
+      actionState = AsyncState.error(message: '공지 생성 실패: $e');
+      notifyListeners();
+    }
+  }
+
+  Future<void> deleteNotice(String noticeId) async {
+    actionState = const AsyncState.loading();
+    notifyListeners();
+
+    try {
+      await _notices.deleteNotice(noticeId);
+      actionState = const AsyncState.success(null);
+      notifyListeners();
+    } catch (e) {
+      actionState = AsyncState.error(message: '공지 삭제 실패: $e');
+      notifyListeners();
+    }
+  }
+
+  void resetActionState() {
+    if (actionState.isError || actionState.isSuccess) {
+      actionState = const AsyncState.idle();
+      notifyListeners();
+    }
+  }
+
+  @override
+  void dispose() {
+    _todoSub?.cancel();
+    _noticeSub?.cancel();
+    super.dispose();
+  }
+}

--- a/todo_mini/lib/features/admin/create_notice_dialog.dart
+++ b/todo_mini/lib/features/admin/create_notice_dialog.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+
+class CreateNoticeDialog extends StatefulWidget {
+  final Future<void> Function(String title, String content) onSubmit;
+
+  const CreateNoticeDialog({
+    super.key,
+    required this.onSubmit,
+  });
+
+  @override
+  State<CreateNoticeDialog> createState() => _CreateNoticeDialogState();
+}
+
+class _CreateNoticeDialogState extends State<CreateNoticeDialog> {
+  final _titleCtrl = TextEditingController();
+  final _contentCtrl = TextEditingController();
+  bool _saving = false;
+
+  @override
+  void dispose() {
+    _titleCtrl.dispose();
+    _contentCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Create Notice'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          TextField(
+            key: const Key('admin_notice_title'),
+            controller: _titleCtrl,
+            decoration: const InputDecoration(labelText: 'Title'),
+          ),
+          const SizedBox(height: 8),
+          TextField(
+            key: const Key('admin_notice_content'),
+            controller: _contentCtrl,
+            decoration: const InputDecoration(labelText: 'Content'),
+            maxLines: 4,
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: _saving ? null : () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        ElevatedButton(
+          key: const Key('admin_notice_submit'),
+          onPressed: _saving
+              ? null
+              : () async {
+                  final title = _titleCtrl.text.trim();
+                  final content = _contentCtrl.text.trim();
+                  if (title.isEmpty || content.isEmpty) return;
+
+                  setState(() => _saving = true);
+                  await widget.onSubmit(title, content);
+                  if (mounted) Navigator.of(context).pop();
+                },
+          child: const Text('Create'),
+        ),
+      ],
+    );
+  }
+}

--- a/todo_mini/lib/features/admin/create_todo_dialog.dart
+++ b/todo_mini/lib/features/admin/create_todo_dialog.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+import '../../data/models/app_user.dart';
+
+/// Todo 생성 다이얼로그(관리자용)
+/// - 필수: title, assignee 선택
+/// - 선택: description
+class CreateTodoDialog extends StatefulWidget {
+  final List<AppUser> users;
+
+  /// (title, description, dueDate, assigneeId)
+  final Future<void> Function(String, String?, DateTime?, String) onSubmit;
+
+  const CreateTodoDialog({
+    super.key,
+    required this.users,
+    required this.onSubmit,
+  });
+
+  @override
+  State<CreateTodoDialog> createState() => _CreateTodoDialogState();
+}
+
+class _CreateTodoDialogState extends State<CreateTodoDialog> {
+  final _titleCtrl = TextEditingController();
+  final _descCtrl = TextEditingController();
+
+  String? _assigneeId;
+  bool _saving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.users.isNotEmpty) {
+      _assigneeId = widget.users.first.id;
+    }
+  }
+
+  @override
+  void dispose() {
+    _titleCtrl.dispose();
+    _descCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Create Todo'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          TextField(
+            key: const Key('admin_todo_title'),
+            controller: _titleCtrl,
+            decoration: const InputDecoration(labelText: 'Title'),
+          ),
+          const SizedBox(height: 8),
+          TextField(
+            key: const Key('admin_todo_desc'),
+            controller: _descCtrl,
+            decoration: const InputDecoration(labelText: 'Description (optional)'),
+          ),
+          const SizedBox(height: 8),
+          DropdownButtonFormField<String>(
+            key: const Key('admin_todo_assignee'),
+            value: _assigneeId,
+            items: widget.users
+                .map((u) => DropdownMenuItem(
+                      value: u.id,
+                      child: Text('${u.name} (${u.role.name})'),
+                    ))
+                .toList(),
+            onChanged: _saving ? null : (v) => setState(() => _assigneeId = v),
+            decoration: const InputDecoration(labelText: 'Assignee'),
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: _saving ? null : () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        ElevatedButton(
+          key: const Key('admin_todo_submit'),
+          onPressed: _saving
+              ? null
+              : () async {
+                  final title = _titleCtrl.text.trim();
+                  final assigneeId = _assigneeId;
+
+                  if (title.isEmpty || assigneeId == null) return;
+
+                  setState(() => _saving = true);
+                  await widget.onSubmit(
+                    title,
+                    _descCtrl.text.trim().isEmpty ? null : _descCtrl.text.trim(),
+                    null,
+                    assigneeId,
+                  );
+                  if (mounted) Navigator.of(context).pop();
+                },
+          child: const Text('Create'),
+        ),
+      ],
+    );
+  }
+}

--- a/todo_mini/lib/features/home/home_placeholder_screen.dart
+++ b/todo_mini/lib/features/home/home_placeholder_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:todo_mini/features/admin/admin_screen.dart';
 import 'package:todo_mini/features/todos/my_todos_screen.dart';
 
 import '../../data/models/app_user.dart';
@@ -68,6 +69,22 @@ class HomePlaceholderScreen extends StatelessWidget {
                 child: const Text('내 할 일 보기'),
               ),
             ),
+
+            if (me.role == UserRole.admin) ...[
+              const SizedBox(height: 12),
+              SizedBox(
+                width: double.infinity,
+                child: OutlinedButton(
+                  key: const Key('btn_open_admin'),
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(builder: (_) => const AdminScreen()),
+                    );
+                  },
+                  child: const Text('관리자 화면'),
+                ),
+              ),
+            ],
 
             const SizedBox(height: 16),
             const Text('Notices 기능이 연결되었습니다.'),

--- a/todo_mini/test/features/admin/admin_view_model_test.dart
+++ b/todo_mini/test/features/admin/admin_view_model_test.dart
@@ -1,0 +1,124 @@
+import 'dart:async';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:todo_mini/core/ui/async_state.dart';
+import 'package:todo_mini/data/models/app_user.dart';
+import 'package:todo_mini/data/models/todo.dart';
+import 'package:todo_mini/data/models/notice.dart';
+
+import 'package:todo_mini/data/repositories/user_repository.dart';
+import 'package:todo_mini/data/repositories/todo_repository.dart';
+import 'package:todo_mini/data/repositories/notice_repository.dart';
+
+import 'package:todo_mini/features/admin/admin_view_model.dart';
+
+class FakeUserRepo implements UserRepository {
+  List<AppUser> users = [];
+
+  @override
+  Future<List<AppUser>> getUsers() async => users;
+
+  @override
+  Future<AppUser> getOrCreateCurrentUser({required String defaultName}) => throw UnimplementedError();
+  @override
+  Future<AppUser> getUserById(String uid) => throw UnimplementedError();
+}
+
+class FakeTodoRepo implements TodoRepository {
+  final controller = StreamController<List<Todo>>.broadcast();
+  bool created = false;
+  bool deleted = false;
+
+  @override
+  Stream<List<Todo>> watchAllTodos() => controller.stream;
+
+  @override
+  Future<void> createTodo(TodoCreateInput input) async {
+    created = true;
+  }
+
+  @override
+  Future<void> deleteTodo(String todoId) async {
+    deleted = true;
+  }
+
+  // user methods unused
+  @override
+  Stream<List<Todo>> watchMyTodos(String myUid) => const Stream.empty();
+  @override
+  Future<void> updateMyTodoStatus({required String todoId, required String myUid, required TodoStatus status}) =>
+      throw UnimplementedError();
+}
+
+class FakeNoticeRepo implements NoticeRepository {
+  final controller = StreamController<List<Notice>>.broadcast();
+  bool created = false;
+  bool deleted = false;
+
+  @override
+  Stream<List<Notice>> watchNotices() => controller.stream;
+
+  @override
+  Future<void> createNotice(NoticeCreateInput input) async {
+    created = true;
+  }
+
+  @override
+  Future<void> deleteNotice(String noticeId) async {
+    deleted = true;
+  }
+}
+
+void main() {
+  test('AdminViewModel loads users and watches todo/notice streams', () async {
+    final usersRepo = FakeUserRepo()
+      ..users = [
+        AppUser(id: 'u1', name: 'A', role: UserRole.user, createdAt: DateTime(2026, 2, 10)),
+      ];
+    final todoRepo = FakeTodoRepo();
+    final noticeRepo = FakeNoticeRepo();
+
+    final vm = AdminViewModel(usersRepo, todoRepo, noticeRepo);
+    await vm.start();
+
+    expect(vm.usersState.status, AsyncStatus.success);
+
+    // stream emit → state update
+    todoRepo.controller.add([
+      Todo(
+        id: 't1',
+        title: 'T',
+        description: null,
+        dueDate: null,
+        status: TodoStatus.open,
+        assigneeId: 'u1',
+        createdAt: DateTime(2026, 2, 10),
+        updatedAt: DateTime(2026, 2, 10),
+      )
+    ]);
+    noticeRepo.controller.add([
+      Notice(
+        id: 'n1',
+        title: 'N',
+        content: 'C',
+        createdAt: DateTime(2026, 2, 10),
+        updatedAt: DateTime(2026, 2, 10),
+      )
+    ]);
+
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    expect(vm.todosState.status, AsyncStatus.success);
+    expect(vm.noticesState.status, AsyncStatus.success);
+  });
+
+  test('AdminViewModel create/delete actions update actionState', () async {
+    final vm = AdminViewModel(FakeUserRepo(), FakeTodoRepo(), FakeNoticeRepo());
+
+    await vm.createNotice(title: 't', content: 'c');
+    expect(vm.actionState.status, AsyncStatus.success);
+
+    await vm.createTodo(title: 't', assigneeId: 'u1');
+    expect(vm.actionState.status, AsyncStatus.success);
+  });
+}


### PR DESCRIPTION
# PR: feature/addAdmin

## What
- Admin 기능 추가
  - Users 목록 조회
  - Todo 생성/삭제
  - Notice 생성/삭제
- admin role일 때만 Home에서 Admin 진입 버튼 노출
- AdminViewModel(AsyncState) + 단위 테스트 추가

## Why
- 과제 스펙의 관리자 기능(CRUD)을 최소 완성으로 연결하기 위함
- USER/ADMIN 권한 분기를 UI/구조 레벨에서 명확히 하기 위함

## How
- AdminViewModel이 users는 1회 로딩, todos/notices는 stream 구독으로 관리
- create/delete 액션은 repository를 통해 수행하고 actionState로 결과를 표현
- Home에서 role == admin인 경우에만 AdminScreen 접근 가능

## Test
```bash
flutter test
